### PR TITLE
Adapts files to dragway's reorganization.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ project(maliput_integration LANGUAGES C CXX VERSION 3.0.0)
 message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
-find_package(dragway REQUIRED)
 find_package(gflags REQUIRED)
 find_package(maliput REQUIRED)
+find_package(maliput_dragway REQUIRED)
 find_package(multilane REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
@@ -59,7 +59,7 @@ if(BUILD_DOCS)
   find_package(ament_cmake_doxygen REQUIRED)
   ament_doxygen_generate(doxygen_maliput_integration
     CONFIG_OVERLAY doc/Doxyfile.overlay.in
-    DEPENDENCIES dragway maliput multilane
+    DEPENDENCIES maliput maliput_dragway multilane
   )
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -11,9 +11,9 @@
 
   <build_depend>ament_cmake_doxygen</build_depend>
 
-  <depend>dragway</depend>
   <depend>libgflags-dev</depend>
   <depend>maliput</depend>
+  <depend>maliput_dragway</depend>
   <depend>multilane</depend>
   <depend>yaml-cpp</depend>
 

--- a/src/maliput_integration/CMakeLists.txt
+++ b/src/maliput_integration/CMakeLists.txt
@@ -6,16 +6,16 @@ add_executable(dragway_to_urdf
 )
 
 ament_target_dependencies(dragway_to_urdf
-  "dragway"
   "maliput"
+  "maliput_dragway"
 )
 
 target_link_libraries(dragway_to_urdf
-    dragway::dragway
     gflags
     maliput::common
     maliput::geometry_base
     maliput::utilities
+    maliput_dragway::maliput_dragway
 )
 
 add_executable(yaml_to_obj

--- a/src/maliput_integration/dragway_to_urdf.cc
+++ b/src/maliput_integration/dragway_to_urdf.cc
@@ -8,12 +8,12 @@
 
 #include <gflags/gflags.h>
 
-#include "dragway/road_geometry.h"
 #include "maliput/api/road_geometry.h"
 #include "maliput/common/filesystem.h"
 #include "maliput/common/logger.h"
 #include "maliput/common/maliput_abort.h"
 #include "maliput/utilities/generate_urdf.h"
+#include "maliput_dragway/road_geometry.h"
 
 DEFINE_int32(num_lanes, 2, "The number of lanes.");
 DEFINE_double(length, 10, "The length of the dragway in meters.");


### PR DESCRIPTION
> Meta issue [`maliput#278`](https://github.com/ToyotaResearchInstitute/maliput/issues/278)

Adapts all files due to the migration from `dragway` to `maliput_dragway`.