### PR TITLE
Disables tsan because not all backends support that build configuration.

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,14 +19,12 @@ jobs:
       image: ubuntu:18.04
     strategy:
       matrix:
-        sanitizer: [none, asan, ubsan, tsan]
+        sanitizer: [none, asan, ubsan]
         include:
           - sanitizer: none
             COMPILER_FLAG: ''
           - sanitizer: asan
             COMPILER_FLAG: ' -DADDRESS_SANITIZER=On'
-          - sanitizer: tsan
-            COMPILER_FLAG: ' -DTHREAD_SANITIZER=On'
           - sanitizer: ubsan
             COMPILER_FLAG: ' -DUNDEFINED_SANITIZER=On'
     env:


### PR DESCRIPTION
Just what the title states. Once all dependencies can work with tsan symbols enabled, we should be able to restore it. 