### PR TITLE
Unifies cmake install paths.

### DIFF
--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -82,8 +82,10 @@ target_link_libraries(maliput_query
 # Install
 ##############################################################################
 
-install(TARGETS maliput_to_urdf maliput_to_obj maliput_to_string maliput_query
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
+install(
+  TARGETS maliput_to_urdf maliput_to_obj maliput_to_string maliput_query
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )

--- a/src/integration/CMakeLists.txt
+++ b/src/integration/CMakeLists.txt
@@ -30,11 +30,11 @@ target_link_libraries(integration
 ##############################################################################
 
 install(
-    TARGETS integration
-    EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  TARGETS integration
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 ament_export_libraries(integration)


### PR DESCRIPTION
Relates to https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/146

Pairs with:

- https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/146
- https://github.com/ToyotaResearchInstitute/maliput-dragway/pull/21
- https://github.com/ToyotaResearchInstitute/maliput-multilane/pull/32