### PR TITLE
Adds maliput_malidrive dependency to CI and try to check out same branches

### DIFF
--- a/.github/try_vcs_checkout
+++ b/.github/try_vcs_checkout
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2020 Toyota Research Institute
+
+CHANGE_BRANCH=$1
+SRC_FOLDER=$2
+
+echo try checking out ${CHANGE_BRANCH}
+vcs custom $SRC_FOLDER --args branch -f $CHANGE_BRANCH origin/$CHANGE_BRANCH > /dev/null || true
+vcs custom $SRC_FOLDER --args merge --no-edit $CHANGE_BRANCH  > /dev/null || true
+DIFF=$(vcs diff -s $SRC_FOLDER | tr -d '.\n')
+if [ ! -z "$DIFF" ]; then
+    echo "Have merge conflicts!"
+    echo $DIFF
+    exit 1
+fi
+vcs status $SRC_FOLDER

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,17 @@ jobs:
     container:
       image: ubuntu:18.04
     steps:
+    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
+    - uses: ros-tooling/setup-ros@0.0.26
+    # install git from ppa since git 2.18+ is needed to fetch all branches from actions/checkout
+    # this step can be removed on 20.04
+    - name: install git from ppa
+      shell: bash
+      run: |
+        apt update;
+        apt install -y software-properties-common;
+        add-apt-repository -y -u ppa:git-core/ppa;
+        apt install -y git;
     - uses: actions/checkout@v2
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
@@ -21,40 +32,43 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput_malidrive
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_malidrive
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-dragway
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_dragway
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-multilane
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_multilane
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/malidrive
-        path: ${{ env.ROS_WS }}/src/malidrive
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
         repository: ToyotaResearchInstitute/drake-vendor
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/drake_vendor
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/dsim-repos-index
+        fetch-depth: 0
         path: dsim-repos-index
         token: ${{ secrets.MALIPUT_TOKEN }}
-    # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@0.0.26
+    - name: check if dependencies have a matching branch
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}/src
+      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
     # install drake_vendor prereqs using dsim-repos-index/tools/prereqs.lib
     - name: install drake_vendor prereqs
       shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -31,6 +31,17 @@ jobs:
       CC: clang
       CXX: clang++
       LINKER_PATH: /usr/bin/llvm-ld
+    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
+    - uses: ros-tooling/setup-ros@0.0.26
+    # install git from ppa since git 2.18+ is needed to fetch all branches from actions/checkout
+    # this step can be removed on 20.04
+    - name: install git from ppa
+      shell: bash
+      run: |
+        apt update;
+        apt install -y software-properties-common;
+        add-apt-repository -y -u ppa:git-core/ppa;
+        apt install -y git;
     steps:
     - uses: actions/checkout@v2
       with:
@@ -39,40 +50,43 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput_malidrive
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_malidrive
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-dragway
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_dragway
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-multilane
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_multilane
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/malidrive
-        path: ${{ env.ROS_WS }}/src/malidrive
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
         repository: ToyotaResearchInstitute/drake-vendor
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/drake_vendor
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/dsim-repos-index
+        fetch-depth: 0
         path: dsim-repos-index
         token: ${{ secrets.MALIPUT_TOKEN }}
-    # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@0.0.26
+    - name: check if dependencies have a matching branch
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}/src
+      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
     # install drake_vendor prereqs using dsim-repos-index/tools/prereqs.lib
     - name: install drake_vendor prereqs
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -18,6 +18,17 @@ jobs:
     container:
       image: ubuntu:18.04
     steps:
+    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
+    - uses: ros-tooling/setup-ros@0.0.26
+    # install git from ppa since git 2.18+ is needed to fetch all branches from actions/checkout
+    # this step can be removed on 20.04
+    - name: install git from ppa
+      shell: bash
+      run: |
+        apt update;
+        apt install -y software-properties-common;
+        add-apt-repository -y -u ppa:git-core/ppa;
+        apt install -y git;
     - uses: actions/checkout@v2
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
@@ -25,40 +36,43 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput_malidrive
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_malidrive
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-dragway
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_dragway
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/maliput-multilane
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/maliput_multilane
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/malidrive
-        path: ${{ env.ROS_WS }}/src/malidrive
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: actions/checkout@v2
-      with:
         repository: ToyotaResearchInstitute/drake-vendor
+        fetch-depth: 0
         path: ${{ env.ROS_WS }}/src/drake_vendor
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
         repository: ToyotaResearchInstitute/dsim-repos-index
+        fetch-depth: 0
         path: dsim-repos-index
         token: ${{ secrets.MALIPUT_TOKEN }}
-    # use setup-ros action to get vcs, rosdep, and colcon
-    - uses: ros-tooling/setup-ros@0.0.26
+    - name: check if dependencies have a matching branch
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}/src
+      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
     # install drake_vendor prereqs using dsim-repos-index/tools/prereqs.lib
     - name: install drake_vendor prereqs
       shell: bash


### PR DESCRIPTION
Related to ToyotaResearchInstitute/maliput_malidrive#1

I took the chance and I modified CI in order to checkout to branches with the same name in the dependant repositories.
Related to this https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/136#issuecomment-717403220