### PR TITLE
Apps: Improve configuration options when loading a malidrive backend.

### DIFF
--- a/include/integration/tools.h
+++ b/include/integration/tools.h
@@ -48,6 +48,9 @@ struct MalidriveBuildProperties {
   double linear_tolerance{5e-2};
   std::string build_policy{"sequential"};
   int number_of_threads{0};
+  std::string simplification_policy{"none"};
+  std::string tolerance_selection_policy{"manual"};
+  std::string standard_strictness_policy{"permissive"};
   std::string road_rule_book_file{""};
   std::string traffic_light_book_file{""};
   std::string phase_ring_book_file{""};

--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -137,7 +137,8 @@ int main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {xodr_file, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_road_rule_book_file,
+      {xodr_file, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 

--- a/src/applications/maliput_gflags.h
+++ b/src/applications/maliput_gflags.h
@@ -43,13 +43,18 @@
 
 #ifndef MALIDRIVE_PROPERTIES_FLAGS
 
-#define MALIDRIVE_PROPERTIES_FLAGS()                                                                  \
-  DEFINE_string(xodr_file_path, "", "XODR file path.");                                               \
-  DEFINE_double(linear_tolerance, 5e-2, "Linear tolerance used to load the map.");                    \
-  DEFINE_string(build_policy, "sequential", "Build policy, it could be `sequential` or `parallel`."); \
-  DEFINE_int32(num_threads, 0, "Number of threads to create the Road Geometry.");                     \
-  DEFINE_string(road_rule_book_file, "", "YAML file defining a Maliput road rule book");              \
-  DEFINE_string(traffic_light_book_file, "", "YAML file defining a Maliput traffic lights book");     \
-  DEFINE_string(phase_ring_book_file, "", "YAML file defining a Maliput phase ring book");            \
+#define MALIDRIVE_PROPERTIES_FLAGS()                                                                                   \
+  DEFINE_string(xodr_file_path, "", "XODR file path.");                                                                \
+  DEFINE_double(linear_tolerance, 5e-2, "Linear tolerance used to load the map.");                                     \
+  DEFINE_string(build_policy, "sequential", "Build policy, it could be `sequential` or `parallel`.");                  \
+  DEFINE_int32(num_threads, 0, "Number of threads to create the Road Geometry.");                                      \
+  DEFINE_string(simplification_policy, "none", "Geometries simplification policy, it could be `none` or `simplify`."); \
+  DEFINE_string(tolerance_selection_policy, "manual",                                                                  \
+                "Tolerance selection policy, it could be `manual` or `automatic`.");                                   \
+  DEFINE_string(standard_strictness_policy, "permissive",                                                              \
+                "OpenDrive standard strictness, it could be `permissive` or `strict`.");                               \
+  DEFINE_string(road_rule_book_file, "", "YAML file defining a Maliput road rule book");                               \
+  DEFINE_string(traffic_light_book_file, "", "YAML file defining a Maliput traffic lights book");                      \
+  DEFINE_string(phase_ring_book_file, "", "YAML file defining a Maliput phase ring book");                             \
   DEFINE_string(intersection_book_file, "", "YAML file defining a Maliput intersection book");
 #endif  // MALIDRIVE_PROPERTIES_FLAGS

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -80,12 +80,14 @@ int Main(int argc, char* argv[]) {
   times.reserve(FLAGS_iterations);
   for (int i = 0; i < FLAGS_iterations; i++) {
     log()->info("Building RoadNetwork {} of {}.", i + 1, FLAGS_iterations);
-    times.push_back(MeasureLoadTime(
-        maliput_implementation,
-        {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height},
-        {FLAGS_yaml_file},
-        {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_road_rule_book_file,
-         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));
+    times.push_back(
+        MeasureLoadTime(maliput_implementation,
+                        {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height},
+                        {FLAGS_yaml_file},
+                        {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads,
+                         FLAGS_simplification_policy, FLAGS_tolerance_selection_policy,
+                         FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
+                         FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));
   }
   const double mean_time = (std::accumulate(times.begin(), times.end(), 0.)) / static_cast<double>(times.size());
   maliput::log()->info("\tMean time was: {}s out of {} iterations.\n", mean_time, FLAGS_iterations);

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -660,7 +660,8 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_road_rule_book_file,
+      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -71,7 +71,8 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_road_rule_book_file,
+      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -57,7 +57,8 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_road_rule_book_file,
+      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 

--- a/src/applications/maliput_to_string_with_plugin.cc
+++ b/src/applications/maliput_to_string_with_plugin.cc
@@ -55,6 +55,8 @@ DEFINE_string(opendrive_file, "install/maliput_malidrive/share/maliput_malidrive
 DEFINE_string(linear_tolerance, "5e-2", "Linear tolerance used to load the map.");
 DEFINE_string(angular_tolerance, "1e-3", "Angular tolerance used to load the map.");
 DEFINE_string(scale_length, "1", "Scale length");
+DEFINE_string(standard_strictness_policy, "permissive",
+              "OpenDrive standard strictness, it could be `permissive` or `strict`");
 
 // Gflags to select options for serialization.
 DEFINE_bool(include_type_labels, false, "Whether to include type labels in the output string");
@@ -83,7 +85,8 @@ int Main(int argc, char* argv[]) {
                                                       {"opendrive_file", FLAGS_opendrive_file},
                                                       {"linear_tolerance", FLAGS_linear_tolerance},
                                                       {"angular_tolerance", FLAGS_angular_tolerance},
-                                                      {"scale_length", FLAGS_scale_length}};
+                                                      {"scale_length", FLAGS_scale_length},
+                                                      {"standard_strictness_policy", FLAGS_standard_strictness_policy}};
 
   maliput::log()->info("Creating MaliputPluginManager instance...");
   maliput::plugin::MaliputPluginManager manager;

--- a/src/applications/maliput_to_urdf.cc
+++ b/src/applications/maliput_to_urdf.cc
@@ -60,7 +60,8 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_road_rule_book_file,
+      {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 

--- a/src/applications/python/maliput_loader.py
+++ b/src/applications/python/maliput_loader.py
@@ -51,6 +51,7 @@ def parse_args():
     my_parser.add_argument('-linear_tolerance', action='store')
     my_parser.add_argument('-angular_tolerance', action='store')
     my_parser.add_argument('-scale_length', action='store')
+    my_parser.add_argument('-standard_strictness_policy', action='store')
     args = my_parser.parse_args()
 
     plugin_name = args.plugin_name

--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -125,8 +125,13 @@ std::unique_ptr<const api::RoadNetwork> CreateMalidriveRoadNetwork(const Malidri
       malidrive::InertialToLaneMappingConfig(malidrive::constants::kExplorationRadius,
                                              malidrive::constants::kNumIterations),
       {malidrive::builder::BuildPolicy::FromStrToType(build_properties.build_policy),
-       build_properties.number_of_threads == 0 ? std::nullopt
-                                               : std::make_optional(build_properties.number_of_threads)}};
+       build_properties.number_of_threads == 0 ? std::nullopt : std::make_optional(build_properties.number_of_threads)},
+      malidrive::builder::RoadGeometryConfiguration::FromStrToSimplificationPolicy(
+          build_properties.simplification_policy),
+      malidrive::builder::RoadGeometryConfiguration::FromStrToToleranceSelectionPolicy(
+          build_properties.tolerance_selection_policy),
+      malidrive::builder::RoadGeometryConfiguration::FromStrToStandardStrictnessPolicy(
+          build_properties.standard_strictness_policy)};
   if (!road_geometry_configuration.opendrive_file.has_value()) {
     MALIPUT_ABORT_MESSAGE("opendrive_file cannot be empty.");
   }


### PR DESCRIPTION
For all the applications:

When using the malidrive backend there are some more policies that could be selected via arguments.
- Simplification policy
- Tolerance selection policy
- Standard strictness policy (Introduced in https://github.com/ToyotaResearchInstitute/maliput_malidrive/pull/62)