### PR TITLE
Pairs app with new flag in the malidrive::RoadGeometryConfiguration.

### DIFF
--- a/include/integration/tools.h
+++ b/include/integration/tools.h
@@ -51,6 +51,7 @@ struct MalidriveBuildProperties {
   std::string simplification_policy{"none"};
   std::string tolerance_selection_policy{"manual"};
   std::string standard_strictness_policy{"permissive"};
+  bool omit_nondrivable_lanes{"true"};
   std::string road_rule_book_file{""};
   std::string traffic_light_book_file{""};
   std::string phase_ring_book_file{""};

--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -138,8 +138,9 @@ int main(int argc, char* argv[]) {
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {xodr_file, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
-       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 
   const double max_length = root_node[kMaxLengthKey].as<double>();

--- a/src/applications/maliput_gflags.h
+++ b/src/applications/maliput_gflags.h
@@ -55,6 +55,7 @@
       standard_strictness_policy, "permissive",                                                                        \
       "OpenDrive standard strictness, it could be `permissive`, `allow_schema_errors`, `allow_semantic_errors` or "    \
       "`strict`. Union of policies are also allowed: 'allow_schema_errors|allow_semantic_errors'");                    \
+  DEFINE_bool(omit_nondrivable_lanes, false, "If true, builder omits non-drivable lanes when building.");              \
   DEFINE_string(road_rule_book_file, "", "YAML file defining a Maliput road rule book");                               \
   DEFINE_string(traffic_light_book_file, "", "YAML file defining a Maliput traffic lights book");                      \
   DEFINE_string(phase_ring_book_file, "", "YAML file defining a Maliput phase ring book");                             \

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -86,8 +86,8 @@ int Main(int argc, char* argv[]) {
                         {FLAGS_yaml_file},
                         {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads,
                          FLAGS_simplification_policy, FLAGS_tolerance_selection_policy,
-                         FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
-                         FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));
+                         FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes, FLAGS_road_rule_book_file,
+                         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));
   }
   const double mean_time = (std::accumulate(times.begin(), times.end(), 0.)) / static_cast<double>(times.size());
   maliput::log()->info("\tMean time was: {}s out of {} iterations.\n", mean_time, FLAGS_iterations);

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -661,8 +661,9 @@ int Main(int argc, char* argv[]) {
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
-       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 
   MALIPUT_DEMAND(rn != nullptr);

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -72,8 +72,9 @@ int Main(int argc, char* argv[]) {
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
-       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 
   // Creates the destination directory if it does not already exist.

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -58,8 +58,9 @@ int Main(int argc, char* argv[]) {
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
-       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 
   const maliput::utility::GenerateStringOptions options{FLAGS_include_type_labels,  FLAGS_include_road_geometry_id,

--- a/src/applications/maliput_to_urdf.cc
+++ b/src/applications/maliput_to_urdf.cc
@@ -61,8 +61,9 @@ int Main(int argc, char* argv[]) {
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, FLAGS_linear_tolerance, FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy,
-       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_tolerance_selection_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->debug("RoadNetwork loaded successfully.");
 
   utility::ObjFeatures features;

--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -131,7 +131,8 @@ std::unique_ptr<const api::RoadNetwork> CreateMalidriveRoadNetwork(const Malidri
       malidrive::builder::RoadGeometryConfiguration::FromStrToToleranceSelectionPolicy(
           build_properties.tolerance_selection_policy),
       malidrive::builder::RoadGeometryConfiguration::FromStrToStandardStrictnessPolicy(
-          build_properties.standard_strictness_policy)};
+          build_properties.standard_strictness_policy),
+      build_properties.omit_nondrivable_lanes};
   if (!road_geometry_configuration.opendrive_file.has_value()) {
     MALIPUT_ABORT_MESSAGE("opendrive_file cannot be empty.");
   }


### PR DESCRIPTION
Adds the optional flag `omit_nondrivables_lanes` to the applications when loading a maliput_malidrive based `RoadGeometry`

Related to https://github.com/ToyotaResearchInstitute/maliput_malidrive/pull/79