### PR TITLE
Set up linker properly when using clang.

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       CC: clang-8
       CXX: clang++-8
-      LINKER_PATH: /usr/bin/lld-8
+      LDFLAGS: -fuse-ld=lld-8
     steps:
     # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
     - uses: ros-tooling/setup-ros@0.2.1
@@ -108,10 +108,9 @@ jobs:
         COMPILER_FLAG: ${{ matrix.COMPILER_FLAG }}
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --cmake-args -DCMAKE_LINKER=${LINKER_PATH} \
-            ${COMPILER_FLAG} \
-            --packages-up-to ${PACKAGE_NAME} \
-            --event-handlers=console_direct+;
+        colcon build --packages-up-to ${PACKAGE_NAME} \
+            --event-handlers=console_direct+ \
+            --cmake-args ${COMPILER_FLAG}
     - name: colcon test
       shell: bash
       working-directory: ${{ env.ROS_WS }}

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -17,7 +17,9 @@ jobs:
     container:
       image: ubuntu:20.04
     env:
-      LINKER_PATH: /usr/bin/lld-8
+      CC: clang-8
+      CXX: clang++-8
+      LDFLAGS: -fuse-ld=lld-8
     steps:
     # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
     - uses: ros-tooling/setup-ros@0.2.1
@@ -95,14 +97,12 @@ jobs:
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         colcon build --packages-up-to ${PACKAGE_NAME} \
           --packages-skip ${PACKAGE_NAME} \
-          --event-handlers=console_direct+ \
-          --cmake-args -DCMAKE_LINKER=${LINKER_PATH}
+          --event-handlers=console_direct+
     - name: scan_build
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         ./src/${PACKAGE_NAME}/.github/run_scan_build \
-            --cmake-args -DCMAKE_LINKER=${LINKER_PATH} \
             --packages-select ${PACKAGE_NAME} \
             --event-handlers=console_direct+;


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196

- It wasn't correct the way we were trying to select the `lld` linker when using clang and by default, it was
linking with `ld`. For some reason `ld` started failing a couple of weeks ago accusing of not finding `LLVMgold.so`
So I fixed it to [use `lld`](https://bcain-llvm.readthedocs.io/projects/lld/en/latest/#using-lld) as it was planned at first and it is working correctly. Furthermore, I ran into some [benchmarks](https://stackoverflow.com/questions/3476093/replacing-ld-with-gold-any-experience/53921263#53921263) were it shows that `lld` linker is even faster.

- I modified the scan-build CI node to build the dependencies packages using `clang` for consistency, given that scan-build is running with `clang`.