### PR TITLE
maliput_query: GetNumberOfLanes command.

### DIFF
--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -625,14 +625,8 @@ class RoadNetworkQuery {
 
   /// Gets number of lanes in the RoadGeometry.
   void GetNumberOfLanes() {
-    unsigned int num_lanes{0};
     const auto start = std::chrono::high_resolution_clock::now();
-    for (int i = 0; i < rn_->road_geometry()->num_junctions(); ++i) {
-      const auto junction = rn_->road_geometry()->junction(i);
-      for (int j = 0; j < junction->num_segments(); ++j) {
-        num_lanes += junction->segment(j)->num_lanes();
-      }
-    }
+    const std::size_t num_lanes{rn_->road_geometry()->ById().GetLanes().size()};
     const auto end = std::chrono::high_resolution_clock::now();
     (*out_) << "Number of lanes in the RoadGeometry: " << num_lanes << std::endl;
     const std::chrono::duration<double> duration = (end - start);


### PR DESCRIPTION
Simple command to get the number of lanes in the RoadGeometry:

Example:

Number of drivable lanes in the RoadGeometry. (`omit_nondrivable_lane` flag is true):
```
maliput_query  --xodr_file_path=Town11.xodr --omit_nondrivable_lanes=true -- GetNumberOfLanes
[INFO] Loading road network using malidrive backend implementation...
[INFO] RoadNetwork loaded successfully.
Number of lanes in the RoadGeometry:  2357
Elapsed Query Time: 0.000248886 s
```

Total number of lanes in the RoadGeometry.( `omit_nondrivable_lane` flag is false):
```
maliput_query  --xodr_file_path=Town11.xodr --omit_nondrivable_lanes=false -- GetNumberOfLanes
[INFO] Loading road network using malidrive backend implementation...
[INFO] RoadNetwork loaded successfully.
Number of lanes in the RoadGeometry:  4912
Elapsed Query Time: 0.000198692 s
```