### PR TITLE
Uses compile definitions for the tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,23 +112,3 @@ jobs:
         . install/setup.bash;
         colcon test --packages-select ${PACKAGE_NAME} --event-handlers=console_direct+;
         colcon test-result --verbose;
-    # Build documentation.
-    - name: colcon build doxygen documentation
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-up-to ${PACKAGE_NAME} \
-            --event-handlers=console_direct+ \
-            --cmake-args -DBUILD_TESTING=ON -DBUILD_DOCS=ON;
-    # Test doxygen documentation.
-    - name: colcon test doxygen documentation
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        . install/setup.bash;
-        colcon test --packages-select ${PACKAGE_NAME} \
-            --ctest-args ' -R' ' maliput_integration_doxygen_warnings' \
-            --event-handlers=console_direct+;
-        colcon test-result --verbose;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         colcon build --packages-up-to ${PACKAGE_NAME} \
           --event-handlers=console_direct+ \
-          --cmake-args -DBUILD_TESTING=OFF -DBUILD_DOCS=OFF;
+          --cmake-args -DBUILD_TESTING=ON -DBUILD_DOCS=OFF;
     # Build tests for current package.
     - name: colcon build tests
       shell: bash
@@ -120,7 +120,7 @@ jobs:
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         colcon build --packages-up-to ${PACKAGE_NAME} \
             --event-handlers=console_direct+ \
-            --cmake-args -DBUILD_TESTING=OFF -DBUILD_DOCS=ON;
+            --cmake-args -DBUILD_TESTING=ON -DBUILD_DOCS=ON;
     # Test doxygen documentation.
     - name: colcon test doxygen documentation
       shell: bash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,8 +11,6 @@ ament_add_pytest_test(maliput_to_obj_test maliput_to_obj_test.py
   ENV "MULTILANE_RESOURCE_ROOT=${MALIPUT_MULTILANE_RESOURCE_PATH}"
 )
 
-message(STATUS "****** maliput_multilane: ${maliput_multilane_DIR}")
-
 if (TARGET maliput_to_obj_test)
 add_dependencies(maliput_to_obj_test maliput_to_obj)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,17 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
 
-ament_add_pytest_test(maliput_to_obj_test maliput_to_obj_test.py WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin TIMEOUT 360)
+
+# TODO(https://github.com/maliput/maliput_infrastructure/issues/222): Use ament_index for finding resources provided by the packages.
+set(MALIPUT_MULTILANE_RESOURCE_PATH "${maliput_multilane_DIR}/..")
+set(MALIPUT_MALIDRIVE_RESOURCE_PATH "${maliput_malidrive_DIR}/..")
+
+ament_add_pytest_test(maliput_to_obj_test maliput_to_obj_test.py
+  WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/bin TIMEOUT 360
+  ENV "MULTILANE_RESOURCE_ROOT=${MALIPUT_MULTILANE_RESOURCE_PATH}"
+)
+
+message(STATUS "****** maliput_multilane: ${maliput_multilane_DIR}")
 
 if (TARGET maliput_to_obj_test)
 add_dependencies(maliput_to_obj_test maliput_to_obj)
@@ -15,6 +25,12 @@ target_link_libraries(tools_test
     maliput::api
     maliput_dragway::maliput_dragway
     maliput_multilane::maliput_multilane
+)
+
+target_compile_definitions(tools_test
+  PRIVATE
+    DEF_MALIDRIVE_RESOURCES="${MALIPUT_MALIDRIVE_RESOURCE_PATH}"
+    DEF_MULTILANE_RESOURCES="${MALIPUT_MULTILANE_RESOURCE_PATH}"
 )
 
 # timer_test
@@ -54,4 +70,9 @@ ament_add_gtest(fixed_phase_iteration_handler_test fixed_phase_iteration_handler
 target_link_libraries(fixed_phase_iteration_handler_test
     integration
     maliput::api
+)
+
+target_compile_definitions(fixed_phase_iteration_handler_test
+  PRIVATE
+    DEF_MALIDRIVE_RESOURCES="${MALIPUT_MALIDRIVE_RESOURCE_PATH}"
 )

--- a/test/fixed_phase_iteration_handler_test.cc
+++ b/test/fixed_phase_iteration_handler_test.cc
@@ -47,19 +47,12 @@ namespace maliput {
 namespace integration {
 namespace {
 
-constexpr char MALIPUT_MALIDRIVE_RESOURCE_VAR[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
-
 // Uses maliput_malidrive's SingleRoadPedestrianCrosswalk phase rings to evaluate the FixedPhaseIterationHandler
 // implementation.
 class FixedPhaseIterationHandlerTest : public ::testing::Test {
  public:
   static constexpr char kYamlFileName[] = "/resources/odr/SingleRoadPedestrianCrosswalk.yaml";
   static constexpr char kXodrFileName[] = "/resources/odr/SingleRoadPedestrianCrosswalk.xodr";
-  const std::string kXodrFilePath{maliput::common::Filesystem::get_env_path(MALIPUT_MALIDRIVE_RESOURCE_VAR) +
-                                  kXodrFileName};
-  const std::string kYamlFilePath{maliput::common::Filesystem::get_env_path(MALIPUT_MALIDRIVE_RESOURCE_VAR) +
-                                  kYamlFileName};
-  const double kPhaseDuration{0.5};
 
   void SetUp() override {
     MalidriveBuildProperties properties{};
@@ -76,6 +69,10 @@ class FixedPhaseIterationHandlerTest : public ::testing::Test {
     ASSERT_NE(timer_, nullptr);
   }
 
+  const std::string kMaliputMalidriveResourcePath{DEF_MALIDRIVE_RESOURCES};
+  const std::string kXodrFilePath{kMaliputMalidriveResourcePath + kXodrFileName};
+  const std::string kYamlFilePath{kMaliputMalidriveResourcePath + kYamlFileName};
+  const double kPhaseDuration{0.5};
   std::unique_ptr<api::RoadNetwork> rn_;
   std::unique_ptr<Timer> timer_;
 };

--- a/test/tools_test.cc
+++ b/test/tools_test.cc
@@ -29,6 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "integration/tools.h"
 
+#include <stdlib.h>
+
 #include <gtest/gtest.h>
 #include <maliput_dragway/road_geometry.h>
 #include <maliput_multilane/builder.h>
@@ -47,7 +49,11 @@ constexpr double kLaneWidth{3.7};
 constexpr double kShoulderWidth{3.};
 constexpr double kMaximumHeight{5.2};
 
+constexpr char MALIPUT_MALIDRIVE_RESOURCE_ROOT[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
+constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
+
 GTEST_TEST(CreateRoadNetwork, MalidriveRoadNetwork) {
+  setenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT, DEF_MALIDRIVE_RESOURCES, 1);
   std::unique_ptr<const api::RoadNetwork> dut = CreateMalidriveRoadNetwork({kXodrFileName, 5e-2});
   EXPECT_NE(nullptr, dut);
   EXPECT_NE(nullptr, dut->road_geometry());
@@ -58,6 +64,7 @@ GTEST_TEST(CreateRoadNetwork, MalidriveRoadNetwork) {
 }
 
 GTEST_TEST(CreateRoadNetwork, MultilaneRoadNetwork) {
+  setenv(MULTILANE_RESOURCE_ROOT, DEF_MULTILANE_RESOURCES, 1);
   std::unique_ptr<const api::RoadNetwork> dut = CreateMultilaneRoadNetwork({kYamlFileName});
   EXPECT_NE(nullptr, dut);
   EXPECT_NE(nullptr, dut->road_geometry());

--- a/test/tools_test.cc
+++ b/test/tools_test.cc
@@ -40,20 +40,27 @@ namespace maliput {
 namespace integration {
 namespace {
 
-constexpr char kYamlFileName[] = "2x2_intersection.yaml";
-constexpr char kYamlFileRoadGeometryId[] = "basic_two_lane_x_intersection";
-constexpr char kXodrFileName[] = "ArcLane.xodr";
-constexpr int kNumLanes{2};
-constexpr double kLength{10.};
-constexpr double kLaneWidth{3.7};
-constexpr double kShoulderWidth{3.};
-constexpr double kMaximumHeight{5.2};
+class CreateMalidriveRoadNetworkTest : public ::testing::Test {
+ public:
+  static constexpr int kOverwrite{1};
+  static constexpr char MALIPUT_MALIDRIVE_RESOURCE_ROOT[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
 
-constexpr char MALIPUT_MALIDRIVE_RESOURCE_ROOT[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
-constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
+  void SetUp() override {
+    const auto env = getenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT);
+    if (env != NULL) env_back_up_ = env;
+    setenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT, DEF_MALIDRIVE_RESOURCES, kOverwrite);
+  }
+  void TearDown() override {
+    unsetenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT);
+    if (!env_back_up_.empty()) setenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT, env_back_up_.c_str(), kOverwrite);
+  }
 
-GTEST_TEST(CreateRoadNetwork, MalidriveRoadNetwork) {
-  setenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT, DEF_MALIDRIVE_RESOURCES, 1);
+ private:
+  std::string env_back_up_{};
+};
+
+TEST_F(CreateMalidriveRoadNetworkTest, MalidriveRoadNetwork) {
+  static constexpr char kXodrFileName[] = "ArcLane.xodr";
   std::unique_ptr<const api::RoadNetwork> dut = CreateMalidriveRoadNetwork({kXodrFileName, 5e-2});
   EXPECT_NE(nullptr, dut);
   EXPECT_NE(nullptr, dut->road_geometry());
@@ -63,15 +70,42 @@ GTEST_TEST(CreateRoadNetwork, MalidriveRoadNetwork) {
   // EXPECT_NE(nullptr, dynamic_cast<const malidrive::RoadGeometry*>(dut->road_geometry()));
 }
 
-GTEST_TEST(CreateRoadNetwork, MultilaneRoadNetwork) {
-  setenv(MULTILANE_RESOURCE_ROOT, DEF_MULTILANE_RESOURCES, 1);
+class CreateMultilaneRoadNetworkTest : public ::testing::Test {
+ public:
+  static constexpr int kOverwrite{1};
+  static constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
+
+  void SetUp() override {
+    const auto env = getenv(MULTILANE_RESOURCE_ROOT);
+    if (env != NULL) env_back_up_ = env;
+    setenv(MULTILANE_RESOURCE_ROOT, DEF_MULTILANE_RESOURCES, kOverwrite);
+  }
+  void TearDown() override {
+    unsetenv(MULTILANE_RESOURCE_ROOT);
+    if (!env_back_up_.empty()) setenv(MULTILANE_RESOURCE_ROOT, env_back_up_.c_str(), kOverwrite);
+  }
+
+ private:
+  std::string env_back_up_{};
+};
+
+TEST_F(CreateMultilaneRoadNetworkTest, MultilaneRoadNetwork) {
+  static constexpr char kYamlFileName[] = "2x2_intersection.yaml";
+  static constexpr char kYamlFileRoadGeometryId[] = "basic_two_lane_x_intersection";
   std::unique_ptr<const api::RoadNetwork> dut = CreateMultilaneRoadNetwork({kYamlFileName});
   EXPECT_NE(nullptr, dut);
   EXPECT_NE(nullptr, dut->road_geometry());
   EXPECT_EQ(dut->road_geometry()->id(), maliput::api::RoadGeometryId{kYamlFileRoadGeometryId});
 }
 
+class CreateDragwayRoadNetworkTest : public ::testing::Test {};
+
 GTEST_TEST(CreateRoadNetwork, DragwayRoadNetwork) {
+  static constexpr int kNumLanes{2};
+  static constexpr double kLength{10.};
+  static constexpr double kLaneWidth{3.7};
+  static constexpr double kShoulderWidth{3.};
+  static constexpr double kMaximumHeight{5.2};
   std::unique_ptr<const api::RoadNetwork> dut =
       CreateDragwayRoadNetwork(DragwayBuildProperties{kNumLanes, kLength, kLaneWidth, kShoulderWidth, kMaximumHeight});
   EXPECT_NE(nullptr, dut);


### PR DESCRIPTION
### Summary

Some tests were relying on env variables such as :
 - `MALIPUT_MALIDRIVE_RESOURCE_ROOT`
 - `MULTILANE_RESOURCE_ROOT` 
 
This requires install folder to be sourced, to avoid this the following approach was followed.
NOTE: This is just a workaround to avoid blocking the current release of the package, however the correct way of addressing this would be to follow https://github.com/maliput/maliput_infrastructure/issues/222.
