### PR TITLE
Adds maliput_osm backend to the applications.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -27,7 +27,15 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput_object
     version: main
+  maliput_osm:
+    type: git
+    url: https://github.com/maliput/maliput_osm
+    version: main
   maliput_py:
     type: git
     url: https://github.com/maliput/maliput_py
+    version: main
+  maliput_sparse:
+    type: git
+    url: https://github.com/maliput/maliput_sparse
     version: main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(maliput_dragway REQUIRED)
 find_package(maliput_malidrive REQUIRED)
 find_package(maliput_multilane REQUIRED)
 find_package(maliput_object REQUIRED)
+find_package(maliput_osm REQUIRED)
 find_package(maliput_py REQUIRED)
 find_package(yaml-cpp REQUIRED)
 

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>maliput_malidrive</depend>
   <depend>maliput_multilane</depend>
   <depend>maliput_object</depend>
+  <depend>maliput_osm</depend>
   <depend>maliput_py</depend>
   <depend>yaml-cpp</depend>
 

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -7,12 +7,9 @@ add_executable(maliput_to_obj
 
 target_link_libraries(maliput_to_obj
     gflags
-    integration
     maliput::common
     maliput::utility
-    maliput_dragway::maliput_dragway
-    maliput_malidrive::loader
-    maliput_multilane::maliput_multilane
+    maliput_integration::integration
 )
 
 add_executable(maliput_to_string
@@ -21,12 +18,9 @@ add_executable(maliput_to_string
 
 target_link_libraries(maliput_to_string
     gflags
-    integration
     maliput::common
     maliput::utility
-    maliput_dragway::maliput_dragway
-    maliput_malidrive::loader
-    maliput_multilane::maliput_multilane
+    maliput_integration::integration
 )
 
 add_executable(maliput_query
@@ -35,12 +29,10 @@ add_executable(maliput_query
 
 target_link_libraries(maliput_query
     gflags
-    integration
     maliput::common
     maliput::utility
-    maliput_dragway::maliput_dragway
     maliput_malidrive::loader
-    maliput_multilane::maliput_multilane
+    maliput_integration::integration
     maliput_object::api
     maliput_object::base
 )
@@ -51,13 +43,10 @@ add_executable(maliput_derive_lane_s_routes
 
 target_link_libraries(maliput_derive_lane_s_routes
     gflags
-    integration
     maliput::common
     maliput::routing
     maliput::utility
-    maliput_dragway::maliput_dragway
-    maliput_malidrive::loader
-    maliput_multilane::maliput_multilane
+    maliput_integration::integration
 )
 
 add_executable(maliput_measure_load_time
@@ -66,13 +55,10 @@ add_executable(maliput_measure_load_time
 
 target_link_libraries(maliput_measure_load_time
     gflags
-    integration
     maliput::common
     maliput::routing
     maliput::utility
-    maliput_dragway::maliput_dragway
-    maliput_malidrive::loader
-    maliput_multilane::maliput_multilane
+    maliput_integration::integration
 )
 
 add_executable(maliput_to_string_with_plugin
@@ -93,11 +79,11 @@ add_executable(maliput_dynamic_environment
 
 target_link_libraries(maliput_dynamic_environment
   gflags
-  integration
   maliput::api
   maliput::plugin
   maliput::common
   maliput::utility
+  maliput_integration::integration
 )
 
 ##############################################################################

--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -76,9 +76,11 @@ using maliput::api::RoadNetwork;
 using maliput::api::RoadPositionResult;
 using maliput::routing::DeriveLaneSRoutes;
 
+COMMON_PROPERTIES_FLAGS();
 MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
@@ -318,6 +320,9 @@ int main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {yaml_file},
       {xodr_file, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy, FLAGS_num_threads,
        FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");

--- a/src/applications/maliput_dynamic_environment.cc
+++ b/src/applications/maliput_dynamic_environment.cc
@@ -65,9 +65,11 @@
 #include "integration/tools.h"
 #include "maliput_gflags.h"
 
+COMMON_PROPERTIES_FLAGS();
 MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
@@ -174,6 +176,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
        FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");

--- a/src/applications/maliput_gflags.h
+++ b/src/applications/maliput_gflags.h
@@ -71,11 +71,21 @@
 
 #endif  // MULTILANE_PROPERTIES_FLAGS
 
+#ifndef COMMON_PROPERTIES_FLAGS
+#define COMMON_PROPERTIES_FLAGS()                                                                 \
+  DEFINE_double(linear_tolerance, 5e-2, "Linear tolerance used to load the map.");                \
+  DEFINE_double(angular_tolerance, 1e-3, "Angular tolerance used to load the map.");              \
+  DEFINE_string(rule_registry_file, "", "YAML file defining a Maliput rule registry");            \
+  DEFINE_string(road_rule_book_file, "", "YAML file defining a Maliput road rule book");          \
+  DEFINE_string(traffic_light_book_file, "", "YAML file defining a Maliput traffic lights book"); \
+  DEFINE_string(phase_ring_book_file, "", "YAML file defining a Maliput phase ring book");        \
+  DEFINE_string(intersection_book_file, "", "YAML file defining a Maliput intersection book");
+#endif  // COMMON_PROPERTIES_FLAGS
+
 #ifndef MALIDRIVE_PROPERTIES_FLAGS
 
 #define MALIDRIVE_PROPERTIES_FLAGS()                                                                                   \
   DEFINE_string(xodr_file_path, "", "XODR file path.");                                                                \
-  DEFINE_double(linear_tolerance, 5e-2, "Linear tolerance used to load the map.");                                     \
   DEFINE_double(max_linear_tolerance, -1., "Maximum linear tolerance used to load the map.");                          \
   DEFINE_string(build_policy, "sequential", "Build policy, it could be `sequential` or `parallel`.");                  \
   DEFINE_int32(num_threads, 0, "Number of threads to create the Road Geometry.");                                      \
@@ -85,11 +95,6 @@
       "OpenDrive standard strictness, it could be `permissive`, `allow_schema_errors`, `allow_semantic_errors` or "    \
       "`strict`. Union of policies are also allowed: 'allow_schema_errors|allow_semantic_errors'");                    \
   DEFINE_bool(omit_nondrivable_lanes, false, "If true, builder omits non-drivable lanes when building.");              \
-  DEFINE_string(rule_registry_file, "", "YAML file defining a Maliput rule registry");                                 \
-  DEFINE_string(road_rule_book_file, "", "YAML file defining a Maliput road rule book");                               \
-  DEFINE_string(traffic_light_book_file, "", "YAML file defining a Maliput traffic lights book");                      \
-  DEFINE_string(phase_ring_book_file, "", "YAML file defining a Maliput phase ring book");                             \
-  DEFINE_string(intersection_book_file, "", "YAML file defining a Maliput intersection book");                         \
   std::optional<double> GetLinearToleranceFlag() {                                                                     \
     return gflags::GetCommandLineFlagInfoOrDie("linear_tolerance").is_default                                          \
                ? std::nullopt                                                                                          \
@@ -101,3 +106,10 @@
                : std::make_optional<double>(FLAGS_max_linear_tolerance);                                               \
   }
 #endif  // MALIDRIVE_PROPERTIES_FLAGS
+
+#ifndef MALIPUT_OSM_PROPERTIES_FLAGS
+
+#define MALIPUT_OSM_PROPERTIES_FLAGS()           \
+  DEFINE_string(osm_file, "", "OSM file path."); \
+  DEFINE_string(origin, "{0., 0.}", "OSM map's origin lat/long coordinate.");
+#endif  // MALIPUT_OSM_PROPERTIES_FLAGS

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -62,9 +62,11 @@ namespace maliput {
 namespace integration {
 namespace {
 
+COMMON_PROPERTIES_FLAGS();
 MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
@@ -84,10 +86,11 @@ DEFINE_int32(iterations, 1, "Number of iterations for loading the Road Geometry.
 double MeasureLoadTime(MaliputImplementation maliput_implementation,
                        const DragwayBuildProperties& dragway_build_properties,
                        const MultilaneBuildProperties& multilane_build_properties,
-                       const MalidriveBuildProperties& malidrive_build_properties) {
+                       const MalidriveBuildProperties& malidrive_build_properties,
+                       const MaliputOsmBuildProperties& maliput_osm_build_properties) {
   const auto start = std::chrono::high_resolution_clock::now();
   const auto rn = LoadRoadNetwork(maliput_implementation, dragway_build_properties, multilane_build_properties,
-                                  malidrive_build_properties);
+                                  malidrive_build_properties, maliput_osm_build_properties);
   const auto end = std::chrono::high_resolution_clock::now();
   const std::chrono::duration<double> duration = (end - start);
   return duration.count();
@@ -114,6 +117,9 @@ int Main(int argc, char* argv[]) {
         {FLAGS_yaml_file},
         {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
          FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+         FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+         FLAGS_intersection_book_file},
+        {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
          FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
          FLAGS_intersection_book_file}));
   }

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -68,9 +68,11 @@
 #include "integration/tools.h"
 #include "maliput_gflags.h"
 
+COMMON_PROPERTIES_FLAGS();
 MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
@@ -980,6 +982,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
        FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});
   MALIPUT_DEMAND(rn != nullptr);

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -61,9 +61,11 @@
 #include "integration/tools.h"
 #include "maliput_gflags.h"
 
+COMMON_PROPERTIES_FLAGS();
 MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "dragway", "Whether to use <dragway>, <multilane> or <malidrive>. Default is dragway.");
@@ -106,6 +108,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
        FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -57,9 +57,11 @@
 #include "integration/tools.h"
 #include "maliput_gflags.h"
 
+COMMON_PROPERTIES_FLAGS();
 MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
@@ -88,6 +90,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
        FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");

--- a/src/integration/CMakeLists.txt
+++ b/src/integration/CMakeLists.txt
@@ -9,6 +9,12 @@ add_library(integration
   tools.cc
 )
 
+add_library(maliput_integration::integration ALIAS integration)
+set_target_properties(integration
+  PROPERTIES
+    OUTPUT_NAME maliput_integration_integration
+)
+
 target_include_directories(integration
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
@@ -19,10 +25,12 @@ target_link_libraries(integration
     maliput::api
     maliput::base
     maliput::common
+  PRIVATE
     maliput_dragway::maliput_dragway
     maliput_malidrive::builder
     maliput_malidrive::loader
     maliput_multilane::maliput_multilane
+    maliput_osm::builder
     yaml-cpp
 )
 

--- a/src/integration/tools.h
+++ b/src/integration/tools.h
@@ -44,6 +44,7 @@ enum class MaliputImplementation {
   kMalidrive,  //< malidrive implementation.
   kDragway,    //< dragway implementation.
   kMultilane,  //< multilane implementation.
+  kOsm,        //< osm implementation.
 };
 
 /// Returns the std::string version of `maliput_impl`.
@@ -88,6 +89,19 @@ struct MalidriveBuildProperties {
   std::string intersection_book_file{""};
 };
 
+/// Contains the attributes needed for building a maliput_osm RoadNetwork.
+struct MaliputOsmBuildProperties {
+  std::string osm_file{""};
+  double linear_tolerance{1e-5};
+  double angular_tolerance{1e-3};
+  maliput::math::Vector2 origin{0., 0.};
+  std::string rule_registry_file{""};
+  std::string road_rule_book_file{""};
+  std::string traffic_light_book_file{""};
+  std::string phase_ring_book_file{""};
+  std::string intersection_book_file{""};
+};
+
 /// Builds an api::RoadNetwork based on Dragway implementation.
 /// @param build_properties Holds the properties to build the RoadNetwork.
 /// @return A maliput::api::RoadNetwork.
@@ -107,18 +121,27 @@ std::unique_ptr<api::RoadNetwork> CreateMultilaneRoadNetwork(const MultilaneBuil
 /// @throw maliput::common::assertion_error When `build_properties.xodr_file_path` is empty.
 std::unique_ptr<api::RoadNetwork> CreateMalidriveRoadNetwork(const MalidriveBuildProperties& build_properties);
 
+/// Builds an api::RoadNetwork based on MaliputOsm implementation.
+/// @param build_properties Holds the properties to build the RoadNetwork.
+/// @return A maliput::api::RoadNetwork.
+///
+/// @throw maliput::common::assertion_error When `build_properties.osm_file` is empty.
+std::unique_ptr<api::RoadNetwork> CreateMaliputOsmRoadNetwork(const MaliputOsmBuildProperties& build_properties);
+
 /// Builds an api::RoadNetwork using the implementation that `maliput_implementation` describes.
 /// @param maliput_implementation One of MaliputImplementation. (kDragway, kMultilane, kMalidrive).
 /// @param dragway_build_properties Holds the properties to build a dragway RoadNetwork.
 /// @param multilane_build_properties Holds the properties to build a multilane RoadNetwork.
 /// @param malidrive_build_properties Holds the properties to build a malidrive RoadNetwork.
+/// @param maliput_osm_build_properties Holds the properties to build a maliput_osm RoadNetwork.
 /// @return A maliput::api::RoadNetwork.
 ///
 /// @throw maliput::common::assertion_error When `maliput_implementation` is unknown.
 std::unique_ptr<api::RoadNetwork> LoadRoadNetwork(MaliputImplementation maliput_implementation,
                                                   const DragwayBuildProperties& dragway_build_properties,
                                                   const MultilaneBuildProperties& multilane_build_properties,
-                                                  const MalidriveBuildProperties& malidrive_build_properties);
+                                                  const MalidriveBuildProperties& malidrive_build_properties,
+                                                  const MaliputOsmBuildProperties& maliput_osm_build_properties);
 
 /// Obtains the correspondent path to the @p resource_name located at the maliput's implementation's resource directory
 /// if exists, otherwise it returns @p resource_name .

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,12 +25,6 @@ target_link_libraries(tools_test
     maliput_multilane::maliput_multilane
 )
 
-target_compile_definitions(tools_test
-  PRIVATE
-    DEF_MALIDRIVE_RESOURCES="${MALIPUT_MALIDRIVE_RESOURCE_PATH}"
-    DEF_MULTILANE_RESOURCES="${MALIPUT_MULTILANE_RESOURCE_PATH}"
-)
-
 # timer_test
 ament_add_gtest(timer_test timer_test.cc)
 target_link_libraries(timer_test

--- a/test/tools_test.cc
+++ b/test/tools_test.cc
@@ -40,24 +40,7 @@ namespace maliput {
 namespace integration {
 namespace {
 
-class CreateMalidriveRoadNetworkTest : public ::testing::Test {
- public:
-  static constexpr int kOverwrite{1};
-  static constexpr char MALIPUT_MALIDRIVE_RESOURCE_ROOT[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
-
-  void SetUp() override {
-    const auto env = getenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT);
-    if (env != NULL) env_back_up_ = env;
-    setenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT, DEF_MALIDRIVE_RESOURCES, kOverwrite);
-  }
-  void TearDown() override {
-    unsetenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT);
-    if (!env_back_up_.empty()) setenv(MALIPUT_MALIDRIVE_RESOURCE_ROOT, env_back_up_.c_str(), kOverwrite);
-  }
-
- private:
-  std::string env_back_up_{};
-};
+class CreateMalidriveRoadNetworkTest : public ::testing::Test {};
 
 TEST_F(CreateMalidriveRoadNetworkTest, MalidriveRoadNetwork) {
   static constexpr char kXodrFileName[] = "ArcLane.xodr";
@@ -70,24 +53,7 @@ TEST_F(CreateMalidriveRoadNetworkTest, MalidriveRoadNetwork) {
   // EXPECT_NE(nullptr, dynamic_cast<const malidrive::RoadGeometry*>(dut->road_geometry()));
 }
 
-class CreateMultilaneRoadNetworkTest : public ::testing::Test {
- public:
-  static constexpr int kOverwrite{1};
-  static constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
-
-  void SetUp() override {
-    const auto env = getenv(MULTILANE_RESOURCE_ROOT);
-    if (env != NULL) env_back_up_ = env;
-    setenv(MULTILANE_RESOURCE_ROOT, DEF_MULTILANE_RESOURCES, kOverwrite);
-  }
-  void TearDown() override {
-    unsetenv(MULTILANE_RESOURCE_ROOT);
-    if (!env_back_up_.empty()) setenv(MULTILANE_RESOURCE_ROOT, env_back_up_.c_str(), kOverwrite);
-  }
-
- private:
-  std::string env_back_up_{};
-};
+class CreateMultilaneRoadNetworkTest : public ::testing::Test {};
 
 TEST_F(CreateMultilaneRoadNetworkTest, MultilaneRoadNetwork) {
   static constexpr char kYamlFileName[] = "2x2_intersection.yaml";
@@ -113,24 +79,7 @@ GTEST_TEST(CreateRoadNetwork, DragwayRoadNetwork) {
   EXPECT_NE(nullptr, dynamic_cast<const dragway::RoadGeometry*>(dut->road_geometry()));
 }
 
-class CreateMaliputOsmRoadNetworkTest : public ::testing::Test {
- public:
-  static constexpr int kOverwrite{1};
-  static constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
-
-  void SetUp() override {
-    const auto env = getenv(MULTILANE_RESOURCE_ROOT);
-    if (env != NULL) env_back_up_ = env;
-    setenv(MULTILANE_RESOURCE_ROOT, DEF_MULTILANE_RESOURCES, kOverwrite);
-  }
-  void TearDown() override {
-    unsetenv(MULTILANE_RESOURCE_ROOT);
-    if (!env_back_up_.empty()) setenv(MULTILANE_RESOURCE_ROOT, env_back_up_.c_str(), kOverwrite);
-  }
-
- private:
-  std::string env_back_up_{};
-};
+class CreateMaliputOsmRoadNetworkTest : public ::testing::Test {};
 
 TEST_F(CreateMaliputOsmRoadNetworkTest, MaliputOsmRoadNetwork) {
   static constexpr char kFileName[] = "straight_forward.osm";

--- a/test/tools_test.cc
+++ b/test/tools_test.cc
@@ -113,6 +113,34 @@ GTEST_TEST(CreateRoadNetwork, DragwayRoadNetwork) {
   EXPECT_NE(nullptr, dynamic_cast<const dragway::RoadGeometry*>(dut->road_geometry()));
 }
 
+class CreateMaliputOsmRoadNetworkTest : public ::testing::Test {
+ public:
+  static constexpr int kOverwrite{1};
+  static constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
+
+  void SetUp() override {
+    const auto env = getenv(MULTILANE_RESOURCE_ROOT);
+    if (env != NULL) env_back_up_ = env;
+    setenv(MULTILANE_RESOURCE_ROOT, DEF_MULTILANE_RESOURCES, kOverwrite);
+  }
+  void TearDown() override {
+    unsetenv(MULTILANE_RESOURCE_ROOT);
+    if (!env_back_up_.empty()) setenv(MULTILANE_RESOURCE_ROOT, env_back_up_.c_str(), kOverwrite);
+  }
+
+ private:
+  std::string env_back_up_{};
+};
+
+TEST_F(CreateMaliputOsmRoadNetworkTest, MaliputOsmRoadNetwork) {
+  static constexpr char kFileName[] = "straight_forward.osm";
+  static constexpr char kRoadGeometryId[] = "maliput_osm_rg";
+  std::unique_ptr<const api::RoadNetwork> dut = CreateMaliputOsmRoadNetwork({kFileName, 1e-3, 1e-3, {0., 0.}});
+  EXPECT_NE(nullptr, dut);
+  EXPECT_NE(nullptr, dut->road_geometry());
+  EXPECT_EQ(dut->road_geometry()->id(), maliput::api::RoadGeometryId{kRoadGeometryId});
+}
+
 }  // namespace
 }  // namespace integration
 }  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_osm/issues/21

## Summary
Adds `maliput_osm` backend to the applications.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
