### PR TITLE
Adds queries to get parameter list from backends.

### DIFF
--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(maliput_query
 target_link_libraries(maliput_query
     gflags
     maliput::common
+    maliput::plugin
     maliput::utility
     maliput_malidrive::loader
     maliput_integration::integration


### PR DESCRIPTION
# 🎉 New feature

Closes #128 

## Summary
 - Adds two commands for getting the list of maliput backends and the parameters for a given backend.

**Important**: The structure of this app will need to change in order to use the maliput plugin architecture. This will be tackled in a follow-up PR. See #105 

## Test it
<!--Explain how reviewers can test this new feature manually.-->
```
maliput_query -- GetMaliputBackendParameters maliput_dragway
```
```
maliput_query -- GetMaliputBackendList
```


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
