### PR TITLE
Relies on maliput_multilane's RN builder.

### DIFF
--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -52,6 +52,7 @@
 #include <maliput_malidrive/loader/loader.h>
 #include <maliput_multilane/builder.h>
 #include <maliput_multilane/loader.h>
+#include <maliput_multilane/road_network_builder.h>
 #include <maliput_osm/builder/road_network_builder.h>
 #include <yaml-cpp/yaml.h>
 
@@ -137,29 +138,9 @@ std::unique_ptr<api::RoadNetwork> CreateMultilaneRoadNetwork(const MultilaneBuil
     MALIPUT_ABORT_MESSAGE("yaml_file cannot be empty.");
   }
   const std::string yaml_file_path = GetResource(MaliputImplementation::kMultilane, build_properties.yaml_file);
-  auto rg = maliput::multilane::LoadFile(maliput::multilane::BuilderFactory(), yaml_file_path);
-  auto rulebook = LoadRoadRulebookFromFile(rg.get(), yaml_file_path);
-  auto traffic_light_book = LoadTrafficLightBookFromFile(yaml_file_path);
-  auto phase_ring_book = LoadPhaseRingBookFromFileOldRules(rulebook.get(), traffic_light_book.get(), yaml_file_path);
-  std::unique_ptr<ManualPhaseProvider> phase_provider = std::make_unique<ManualPhaseProvider>();
-  auto intersection_book =
-      LoadIntersectionBookFromFile(yaml_file_path, *rulebook, *phase_ring_book, rg.get(), phase_provider.get());
-  std::unique_ptr<api::rules::RuleRegistry> rule_registry = std::make_unique<api::rules::RuleRegistry>();
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  std::unique_ptr<ManualRightOfWayRuleStateProvider> right_of_way_rule_state_provider =
-      std::make_unique<ManualRightOfWayRuleStateProvider>();
-#pragma GCC diagnostic pop
-  std::unique_ptr<ManualDiscreteValueRuleStateProvider> discrete_value_rule_state_provider =
-      std::make_unique<ManualDiscreteValueRuleStateProvider>(rulebook.get());
-  std::unique_ptr<ManualRangeValueRuleStateProvider> range_value_rule_state_provider =
-      std::make_unique<ManualRangeValueRuleStateProvider>(rulebook.get());
-  return std::make_unique<api::RoadNetwork>(std::move(rg), std::move(rulebook), std::move(traffic_light_book),
-                                            std::move(intersection_book), std::move(phase_ring_book),
-                                            std::move(right_of_way_rule_state_provider), std::move(phase_provider),
-                                            std::move(rule_registry), std::move(discrete_value_rule_state_provider),
-                                            std::move(range_value_rule_state_provider));
+  maliput::multilane::RoadNetworkConfiguration config;
+  config.yaml_file = yaml_file_path;
+  return maliput::multilane::BuildRoadNetwork(config);
 }
 
 std::unique_ptr<api::RoadNetwork> CreateMalidriveRoadNetwork(const MalidriveBuildProperties& build_properties) {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Relies on maliput_multilane's road network builder:
 - This fixes a bug that forced the user to provide a full yaml file (with rule information) even when it isn't necessary for the road geometry.

## How to replicate bug
```
maliput_query --maliput_backend=multilane --yaml_file=circuit.yaml -- GetLaneLength l:s10_0
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
