### PR TITLE
Removes maliput_drake from CI.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -7,10 +7,6 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput
     version: main
-  maliput_drake:
-    type: git
-    url: https://github.com/maliput/maliput_drake
-    version: main
   maliput_dragway:
     type: git
     url: https://github.com/maliput/maliput_dragway


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_infrastructure/issues/309

:exclamation: :star2:  This PR needs to be merged in sync with others!

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/dbf483d3baf50b995cf1ab94e36e1699/raw/bac535fbb9691771623688b08c51ce5cf4cc66cd/maliput_integration.repos

