### PR TITLE
Provides a way to execute the DistanceRouter via maliput_query and inspect Routes.

### DIFF
--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -30,7 +30,9 @@ add_executable(maliput_query
 target_link_libraries(maliput_query
     gflags
     maliput::common
+    maliput::base
     maliput::plugin
+    maliput::routing
     maliput::utility
     maliput_malidrive::loader
     maliput_integration::integration

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -1318,8 +1318,7 @@ int Main(int argc, char* argv[]) {
     const maliput::api::LaneId end_lane_id = LaneIdFromCLI(&(argv[4]));
     const maliput::api::LanePosition end_lane_pos(SFromCLI(&(argv[5])), 0., 0.);
     const maliput::routing::RoutingConstraints constraints = RoutingConstraintsFromCLI(&(argv[6]));
-    const maliput::DistanceRouter router(const_cast<maliput::api::RoadNetwork*>(rn_ptr),
-                                         rn_ptr->road_geometry()->linear_tolerance());
+    const maliput::DistanceRouter router(*rn_ptr, rn_ptr->road_geometry()->linear_tolerance());
     query.FindRoutes(start_lane_id, start_lane_pos, end_lane_id, end_lane_pos, router, constraints);
   }
 


### PR DESCRIPTION
# 🎉 New feature

Goes hand in hand with: https://github.com/maliput/maliput/pull/619

## Summary

Extends `maliput_query` so it can execute the `DistanceRouter` and evaluate `Route` results.
 
## Test it

Try the following in your console once the workspace has been properly built and sourced:

```sh
$ maliput_query --maliput_backend=malidrive --xodr_file_path=TShapeRoad.xodr \
> FindRoutes 1_0_1 1 4_0_1 10 true 1000 1000
[INFO] Loading road network using malidrive backend implementation...

[INFO] RoadNetwork loaded successfully.

The Routes from (lane: 1_0_1, lane_pos: (s = 1, r = 0, h = 0)) to (lane: 4_0_1, lane_pos: (s = 1, r = 0, h = 0)) are: 
        - Route(phases: [Phase(index: 0, lane_s_range_tolerance: 0.05, start_positions: [(lane: 1_0_1, lane_pos: (s = 1, r = 0, h = 0)), ], end_positions: [(lane: 1_0_1, lane_pos: (s = 0, r = 0, h = 0)), ], lane_s_ranges: [Range(lane_id: 1_0_1, s_range:[1, 0]), ]), Phase(index: 1, lane_s_range_tolerance: 0.05, start_positions: [(lane: 4_0_1, lane_pos: (s = 8, r = 0, h = 0)), ], end_positions: [(lane: 4_0_1, lane_pos: (s = 1, r = 0, h = 0)), ], lane_s_ranges: [Range(lane_id: 4_0_1, s_range:[8, 1]), ]), ])
```
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
