### PR TITLE
Adds angular_tolerance to the build configurations for malidrive RoadNetworks in the applications

### DIFF
--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -318,8 +318,8 @@ int main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {yaml_file},
-      {xodr_file, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy, FLAGS_num_threads,
-       FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
+      {xodr_file, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(), FLAGS_build_policy,
+       FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),

--- a/src/applications/maliput_dynamic_environment.cc
+++ b/src/applications/maliput_dynamic_environment.cc
@@ -174,13 +174,13 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
-       FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file});
+      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
+       FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
+       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
+       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
+       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 
   const std::unique_ptr<const Timer> timer = CreateTimer(TimerType::kChronoTimer);

--- a/src/applications/maliput_gflags.h
+++ b/src/applications/maliput_gflags.h
@@ -104,6 +104,11 @@
     return gflags::GetCommandLineFlagInfoOrDie("max_linear_tolerance").is_default                                      \
                ? std::nullopt                                                                                          \
                : std::make_optional<double>(FLAGS_max_linear_tolerance);                                               \
+  }                                                                                                                    \
+  std::optional<double> GetAngularToleranceFlag() {                                                                    \
+    return gflags::GetCommandLineFlagInfoOrDie("angular_tolerance").is_default                                         \
+               ? std::nullopt                                                                                          \
+               : std::make_optional<double>(FLAGS_angular_tolerance);                                                  \
   }
 #endif  // MALIDRIVE_PROPERTIES_FLAGS
 

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -115,13 +115,13 @@ int Main(int argc, char* argv[]) {
         maliput_implementation,
         {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height},
         {FLAGS_yaml_file},
-        {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
-         FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
-         FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-         FLAGS_intersection_book_file},
-        {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
-         FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-         FLAGS_intersection_book_file}));
+        {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
+         FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
+         FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+        {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
+         maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));
   }
   const double mean_time = (std::accumulate(times.begin(), times.end(), 0.)) / static_cast<double>(times.size());
   maliput::log()->info("\tMean time was: ", mean_time, "s out of ", FLAGS_iterations, " iterations.\n");

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -1099,13 +1099,13 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
-       FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file});
+      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
+       FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
+       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
+       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
+       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   MALIPUT_DEMAND(rn != nullptr);
   log()->info("RoadNetwork loaded successfully.");
 

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -114,13 +114,13 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
-       FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file});
+      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
+       FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
+       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
+       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
+       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 
   // Creates the destination directory if it does not already exist.

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -88,13 +88,13 @@ int Main(int argc, char* argv[]) {
   auto rn = LoadRoadNetwork(
       maliput_implementation,
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
-      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), FLAGS_build_policy,
-       FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file});
+      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
+       FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
+       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
+       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
+       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
   if (FLAGS_check_invariants) {
     log()->info("Checking invariants...");

--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -158,7 +158,9 @@ std::unique_ptr<api::RoadNetwork> CreateMalidriveRoadNetwork(const MalidriveBuil
     road_network_configuration.emplace("max_linear_tolerance",
                                        std::to_string(build_properties.max_linear_tolerance.value()));
   }
-  road_network_configuration.emplace("angular_tolerance", std::to_string(malidrive::constants::kAngularTolerance));
+  if (build_properties.angular_tolerance.has_value()) {
+    road_network_configuration.emplace("angular_tolerance", std::to_string(build_properties.angular_tolerance.value()));
+  }
   road_network_configuration.emplace("scale_length", std::to_string(malidrive::constants::kScaleLength));
   road_network_configuration.emplace("inertial_to_backend_frame_translation", "{0., 0., 0.}");
   road_network_configuration.emplace("build_policy", build_properties.build_policy);

--- a/src/integration/tools.h
+++ b/src/integration/tools.h
@@ -77,6 +77,7 @@ struct MalidriveBuildProperties {
   std::string xodr_file_path{""};
   std::optional<double> linear_tolerance{std::nullopt};
   std::optional<double> max_linear_tolerance{std::nullopt};
+  std::optional<double> angular_tolerance{std::nullopt};
   std::string build_policy{"sequential"};
   int number_of_threads{0};
   std::string simplification_policy{"none"};


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
When trying to pass the angular_tolerance flag to malidrive RoadNetworks, it was parsed but not set as a configuration parameter and only the default was used instead. Now, the value is read from the input arguments and configured into the struct so it is considered when loading a map of that type.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
