### PR TITLE
Provides an integration application to export a RoadGeometry as a DOT file

### DIFF
--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -1,6 +1,18 @@
 ##############################################################################
 # Sources
 ##############################################################################
+add_executable(maliput_to_dot
+  maliput_to_dot.cc
+)
+
+target_link_libraries(maliput_to_dot
+    gflags
+    maliput::common
+    maliput::routing
+    maliput::utility
+    maliput_integration::integration
+)
+
 add_executable(maliput_to_obj
   maliput_to_obj.cc
 )
@@ -97,6 +109,7 @@ install(
     maliput_dynamic_environment
     maliput_measure_load_time
     maliput_query
+    maliput_to_dot
     maliput_to_obj
     maliput_to_string
     maliput_to_string_with_plugin

--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -46,7 +46,7 @@
 /// 2. Comments about the config_file:
 ///      i - It should have a valid xodr_file only when malidrive backend is selected.
 ///     ii - If a xodr_file_path(gflag) is provided then the xodr file path described in the config_file is discarded.
-/// 3. The level of the logger could be setted by: -log_level.
+/// 3. The log level could be setted by: -log_level.
 
 #include <cmath>
 #include <iostream>

--- a/src/applications/maliput_dynamic_environment.cc
+++ b/src/applications/maliput_dynamic_environment.cc
@@ -45,7 +45,7 @@
 ///   2. The application allows to select:
 ///      `-phase_duration`: the duration of each phase.
 ///      `-timeout`: the duration of the simulation.
-///   3. The level of the logger is selected with `-log_level`.
+///   3. The log level is selected with `-log_level`.
 
 #include <map>
 #include <memory>

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -42,10 +42,10 @@
 ///           -yaml_file.
 ///      - "malidrive": xodr file path must be provided and other arguments are optional:
 ///           -xodr_file_path -linear_tolerance -build_policy -num_threads.
-///   2. The applications allows you to load a xodr multiple times and calculate a mean.
+///   2. The application allows you to load a xodr multiple times and calculate a mean.
 ///      The number of iterations could be changed using:
 ///      -iterations
-///   3. The level of the logger is selected with `-log_level`.
+///   3. The log level is selected with `-log_level`.
 
 #include <chrono>
 #include <numeric>

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -42,7 +42,7 @@
 ///    - "malidrive": xodr file path must be provided, tolerance and rule file paths are optional:
 ///         -xodr_file_path -linear_tolerance -road_rule_book_file -traffic_light_book_file -phase_ring_book_file
 ///         -intersection_book_file
-/// 2. The level of the logger could be setted by: -log_level.
+/// 2. The log level could be set by: -log_level.
 
 #include <chrono>
 #include <iostream>

--- a/src/applications/maliput_to_dot.cc
+++ b/src/applications/maliput_to_dot.cc
@@ -1,0 +1,123 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// @file maliput_to_dot.cc
+///
+/// Builds a dragway, multilane or malidrive road geometry
+/// and creates a routing::graph::Graph from it to then serialize to a file a DOT representation.
+///
+/// @note
+/// 1. It allows to create an OBJ file from different road geometry implementations.
+///     The `maliput_backend` flag will determine the backend to be used.
+///    - "dragway": The following flags are supported to use in order to create dragway road geometry:
+///       -num_lanes, -length, -lane_width, -shoulder_width, -maximum_height.
+///    - "multilane": yaml file path must be provided:
+///       -yaml_file.
+///    - "malidrive": xodr file path must be provided and the tolerance is optional:
+///         -xodr_file_path -linear_tolerance.
+/// 2. The applications possesses flags to modify the DOT file builder:
+///      -dot_dir_path, -dot_file_name
+/// 3. The level of the logger could be setted by: -log_level.
+
+#include <fstream>
+#include <limits>
+#include <string>
+
+#include <gflags/gflags.h>
+#include <maliput/common/filesystem.h>
+#include <maliput/common/logger.h>
+#include <maliput/common/maliput_abort.h>
+#include <maliput/routing/graph/graph.h>
+#include <maliput/utility/generate_dot.h>
+
+#include "integration/tools.h"
+#include "maliput_gflags.h"
+
+COMMON_PROPERTIES_FLAGS();
+MULTILANE_PROPERTIES_FLAGS();
+DRAGWAY_PROPERTIES_FLAGS();
+MALIDRIVE_PROPERTIES_FLAGS();
+MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
+
+DEFINE_string(maliput_backend, "dragway", "Whether to use <dragway>, <multilane> or <malidrive>. Default is dragway.");
+
+// Gflags for output files.
+DEFINE_string(dot_dir_path, ".", "Directory to contain DOT file.");
+DEFINE_string(dot_file_name, "maliput_graph.dot", "Name of the maliput::routing::graph::Graph DOT file.");
+
+namespace maliput {
+namespace integration {
+namespace {
+
+// Generates an OBJ file from a YAML file path or from
+// configurable values given as CLI arguments.
+int Main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  common::set_log_level(FLAGS_log_level);
+
+  log()->info("Loading road network using ", FLAGS_maliput_backend, " backend implementation...");
+  const MaliputImplementation maliput_implementation{StringToMaliputImplementation(FLAGS_maliput_backend)};
+  auto rn = LoadRoadNetwork(
+      maliput_implementation,
+      {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
+      {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
+       FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
+       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
+       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
+       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+  log()->info("RoadNetwork loaded successfully.");
+
+  // Creates the destination directory if it does not already exist.
+  common::Path directory;
+  directory.set_path(FLAGS_dot_dir_path);
+  if (!directory.exists()) {
+    common::Filesystem::create_directory_recursive(directory);
+  }
+  MALIPUT_THROW_UNLESS(directory.exists());
+
+  const std::string dot_file_path = FLAGS_dot_dir_path + "/" + FLAGS_dot_file_name;
+  std::ofstream os(dot_file_path, std::ios::binary);
+
+  log()->info("Generating DOT file at ", dot_file_path, " ...");
+  utility::GenerateDotStream(routing::graph::BuildGraph(rn->road_geometry()), &os);
+  log()->info("Generated DOT file.");
+
+  os.close();
+
+  return 0;
+}
+
+}  // namespace
+}  // namespace integration
+}  // namespace maliput
+
+int main(int argc, char* argv[]) { return maliput::integration::Main(argc, argv); }

--- a/src/applications/maliput_to_dot.cc
+++ b/src/applications/maliput_to_dot.cc
@@ -30,10 +30,10 @@
 /// @file maliput_to_dot.cc
 ///
 /// Builds a dragway, multilane or malidrive road geometry
-/// and creates a routing::graph::Graph from it to then serialize to a file a DOT representation.
+/// and creates a routing::graph::Graph from it to then serialize to a DOT file representation.
 ///
 /// @note
-/// 1. It allows to create an OBJ file from different road geometry implementations.
+/// 1. It allows to create an DOT file from different road geometry implementations.
 ///     The `maliput_backend` flag will determine the backend to be used.
 ///    - "dragway": The following flags are supported to use in order to create dragway road geometry:
 ///       -num_lanes, -length, -lane_width, -shoulder_width, -maximum_height.
@@ -41,9 +41,9 @@
 ///       -yaml_file.
 ///    - "malidrive": xodr file path must be provided and the tolerance is optional:
 ///         -xodr_file_path -linear_tolerance.
-/// 2. The applications possesses flags to modify the DOT file builder:
+/// 2. The application possesses flags to modify the DOT file builder:
 ///      -dot_dir_path, -dot_file_name
-/// 3. The level of the logger could be setted by: -log_level.
+/// 3. The log level could be set by: -log_level.
 
 #include <fstream>
 #include <limits>
@@ -76,9 +76,29 @@ namespace maliput {
 namespace integration {
 namespace {
 
-// Generates an OBJ file from a YAML file path or from
+// Generates an DOT file from a YAML file path or from
 // configurable values given as CLI arguments.
 int Main(int argc, char* argv[]) {
+  static constexpr const char* kUsageMessage = R"*(
+Builds a dragway, multilane or malidrive road geometry and creates a routing::graph::Graph from it to then serialize to a DOT file representation.
+
+1. It allows to create an DOT file from different road geometry implementations.
+    The `maliput_backend` flag will determine the backend to be used.
+   - "dragway": The following flags are supported to use in order to create dragway road geometry:
+      -num_lanes, -length, -lane_width, -shoulder_width, -maximum_height.
+   - "multilane": yaml file path must be provided:
+      -yaml_file.
+   - "malidrive": xodr file path must be provided and the tolerance is optional:
+        -xodr_file_path -linear_tolerance.
+2. The application possesses flags to modify the DOT file builder:
+     -dot_dir_path, -dot_file_name
+3. The log level could be set by: -log_level.
+
+Example:
+
+maliput_to_dot --maliput_backend malidrive --xodr_file_path TShapeRoad.xodr
+)*";
+  gflags::SetUsageMessage(kUsageMessage);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   common::set_log_level(FLAGS_log_level);
 

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -42,10 +42,10 @@
 ///       -yaml_file.
 ///    - "malidrive": xodr file path must be provided and the tolerance is optional:
 ///         -xodr_file_path -linear_tolerance.
-/// 2. The applications possesses flags to modify the OBJ file builder:
+/// 2. The application possesses flags to modify the OBJ file builder:
 ///      -obj_dir, -obj_file, -max_grid_unit, -min_grid_resolution, -draw_elevation_bounds, -simplify_mesh_threshold
 /// 3. An urdf file can also be created by passing -urdf flag.
-/// 4. The level of the logger could be setted by: -log_level.
+/// 4. The log level could be set by: -log_level.
 
 #include <limits>
 #include <string>

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -41,10 +41,10 @@
 ///           -yaml_file.
 ///      - "malidrive": xodr file path must be provided and the tolerance is optional:
 ///           -xodr_file_path -linear_tolerance.
-///   2. The applications possesses flags to modify the output serialization:
+///   2. The application possesses flags to modify the output serialization:
 ///      -include_type_labels, -include_road_geometry_id, -include_junction_ids,
 ///      -include_segment_ids, -include_lane_ids, -include_lane_details.
-///   3. The level of the logger is selected with `-log_level`.
+///   3. The log level is selected with `-log_level`.
 
 #include <iostream>
 #include <memory>

--- a/src/applications/maliput_to_string_with_plugin.cc
+++ b/src/applications/maliput_to_string_with_plugin.cc
@@ -45,10 +45,10 @@
 ///           -yaml_file.
 ///       - "maliput_malidrive": xodr file path must be provided, the tolerances and scale length are optional:
 ///           -xodr_file_path, -linear_tolerance, -angular_tolerance, -scale_length.
-///   2. The applications possesses flags to modify the output serialization:
+///   2. The application possesses flags to modify the output serialization:
 ///      -include_type_labels, -include_road_geometry_id, -include_junction_ids,
 ///      -include_segment_ids, -include_lane_ids, -include_lane_details.
-///   3. The level of the logger is selected with `-log_level`.
+///   3. The log level is selected with `-log_level`.
 
 #include <iostream>
 #include <map>


### PR DESCRIPTION
# 🎉 New feature

Pairs with https://github.com/maliput/maliput/pull/637

## Summary

Try it by calling:
```
$ maliput_to_dot --maliput_backend malidrive --xodr_file_path ./src/maliput_malidrive/resources/TShapeRoad.xodr
```
And then see the output value:
```
$ cat maliput_graph.dot
graph {
1 -- 5 [ label = "9_0" ];
5 -- 1 [ label = "8_0" ];
5 -- 2 [ label = "7_0" ];
1 -- 2 [ label = "5_0" ];
4 -- 5 [ label = "2_0" ];
2 -- 5 [ label = "6_0" ];
1 -- 2 [ label = "4_0" ];
2 -- 3 [ label = "1_0" ];
0 -- 1 [ label = "0_0" ];
}
```

Rendering can be seen [here](https://dreampuf.github.io/GraphvizOnline/#graph%20%7B%0A1%20--%205%20%5B%20label%20%3D%20%229_0%22%20%5D%3B%0A5%20--%201%20%5B%20label%20%3D%20%228_0%22%20%5D%3B%0A5%20--%202%20%5B%20label%20%3D%20%227_0%22%20%5D%3B%0A1%20--%202%20%5B%20label%20%3D%20%225_0%22%20%5D%3B%0A4%20--%205%20%5B%20label%20%3D%20%222_0%22%20%5D%3B%0A2%20--%205%20%5B%20label%20%3D%20%226_0%22%20%5D%3B%0A1%20--%202%20%5B%20label%20%3D%20%224_0%22%20%5D%3B%0A2%20--%203%20%5B%20label%20%3D%20%221_0%22%20%5D%3B%0A0%20--%201%20%5B%20label%20%3D%20%220_0%22%20%5D%3B%0A%7D).

## Test it
See instructions above.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
