### PR TITLE
Adds malidrive param: Integrator accuracy multiplier

### DIFF
--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -320,8 +320,8 @@ int main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {yaml_file},
       {xodr_file, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(), FLAGS_build_policy,
        FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy, FLAGS_omit_nondrivable_lanes,
-       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
-       FLAGS_intersection_book_file},
+       FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});

--- a/src/applications/maliput_dynamic_environment.cc
+++ b/src/applications/maliput_dynamic_environment.cc
@@ -176,8 +176,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
        FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
-       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
-       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+       FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});

--- a/src/applications/maliput_gflags.h
+++ b/src/applications/maliput_gflags.h
@@ -95,6 +95,8 @@
       "OpenDrive standard strictness, it could be `permissive`, `allow_schema_errors`, `allow_semantic_errors` or "    \
       "`strict`. Union of policies are also allowed: 'allow_schema_errors|allow_semantic_errors'");                    \
   DEFINE_bool(omit_nondrivable_lanes, false, "If true, builder omits non-drivable lanes when building.");              \
+  DEFINE_double(integrator_accuracy_multiplier, 1.,                                                                    \
+                "Integrator accuracy multiplier used to build the Road Geometry.");                                    \
   std::optional<double> GetLinearToleranceFlag() {                                                                     \
     return gflags::GetCommandLineFlagInfoOrDie("linear_tolerance").is_default                                          \
                ? std::nullopt                                                                                          \

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -117,8 +117,9 @@ int Main(int argc, char* argv[]) {
         {FLAGS_yaml_file},
         {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
          FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
-         FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+         FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file,
+         FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+         FLAGS_intersection_book_file},
         {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
          maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
          FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -1221,8 +1221,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
        FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
-       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
-       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+       FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});

--- a/src/applications/maliput_to_dot.cc
+++ b/src/applications/maliput_to_dot.cc
@@ -109,8 +109,9 @@ maliput_to_dot --maliput_backend malidrive --xodr_file_path TShapeRoad.xodr
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
        FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
-       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
-       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+       FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -136,8 +136,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
        FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
-       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
-       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+       FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -90,8 +90,9 @@ int Main(int argc, char* argv[]) {
       {FLAGS_num_lanes, FLAGS_length, FLAGS_lane_width, FLAGS_shoulder_width, FLAGS_maximum_height}, {FLAGS_yaml_file},
       {FLAGS_xodr_file_path, GetLinearToleranceFlag(), GetMaxLinearToleranceFlag(), GetAngularToleranceFlag(),
        FLAGS_build_policy, FLAGS_num_threads, FLAGS_simplification_policy, FLAGS_standard_strictness_policy,
-       FLAGS_omit_nondrivable_lanes, FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file,
-       FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+       FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
        FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});

--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -171,6 +171,8 @@ std::unique_ptr<api::RoadNetwork> CreateMalidriveRoadNetwork(const MalidriveBuil
   road_network_configuration.emplace("standard_strictness_policy", build_properties.standard_strictness_policy);
   road_network_configuration.emplace("omit_nondrivable_lanes",
                                      build_properties.omit_nondrivable_lanes ? "true" : "false");
+  road_network_configuration.emplace("integrator_accuracy_multiplier",
+                                     std::to_string(build_properties.integrator_accuracy_multiplier));
   if (!build_properties.rule_registry_file.empty()) {
     road_network_configuration.emplace(
         "rule_registry", GetResource(MaliputImplementation::kMalidrive, build_properties.rule_registry_file));

--- a/src/integration/tools.h
+++ b/src/integration/tools.h
@@ -83,6 +83,7 @@ struct MalidriveBuildProperties {
   std::string simplification_policy{"none"};
   std::string standard_strictness_policy{"permissive"};
   bool omit_nondrivable_lanes{"true"};
+  double integrator_accuracy_multiplier{1.0};
   std::string rule_registry_file{""};
   std::string road_rule_book_file{""};
   std::string traffic_light_book_file{""};


### PR DESCRIPTION
# 🎉 New feature

Pairs with https://github.com/maliput/maliput_malidrive/pull/313

## Summary
- ditto

## Test it
<!--Explain how reviewers can test this new feature manually.-->
```
maliput_query --maliput_backend=malidrive --xodr_file_path=TShapeRoad.xodr --integrator_accuracy_multiplier=0.01 -- ToRoadPosition 0.0 -1.5 2.0
```
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
