### PR TITLE
Adding geopackage support

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -27,6 +27,10 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput_osm
     version: main
+  maliput_geopackage:
+    type: git
+    url: https://github.com/maliput/maliput_geopackage
+    version: main
   maliput_py:
     type: git
     url: https://github.com/maliput/maliput_py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(maliput_multilane REQUIRED)
 find_package(maliput_object REQUIRED)
 find_package(maliput_sparse REQUIRED)
 find_package(maliput_osm REQUIRED)
+find_package(maliput_geopackage REQUIRED)
 find_package(maliput_py REQUIRED)
 find_package(yaml-cpp REQUIRED)
 

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>maliput</depend>
   <depend>maliput_dragway</depend>
   <depend>maliput_malidrive</depend>
+  <depend>maliput_geopackage</depend>
   <depend>maliput_multilane</depend>
   <depend>maliput_object</depend>
   <depend>maliput_osm</depend>

--- a/src/applications/maliput_derive_lane_s_routes.cc
+++ b/src/applications/maliput_derive_lane_s_routes.cc
@@ -81,10 +81,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
-              "Whether to use <dragway>, <multilane> or <malidrive>. Default is malidrive.");
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage>. Default is malidrive.");
 DEFINE_string(config_file, "", "YAML file that defines XODR file path, route max length, and start/end waypoints.");
 DEFINE_double(max_length, 1000, "Maximum length of the intermediate lanes between start and end waypoints.[m]");
 DEFINE_string(start_waypoint, "", "Start waypoint to calculate the routing from. Expected format: '{x0, y0, z0}' ");
@@ -325,6 +326,9 @@ int main(int argc, char* argv[]) {
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
+      {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 

--- a/src/applications/maliput_dynamic_environment.cc
+++ b/src/applications/maliput_dynamic_environment.cc
@@ -70,10 +70,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
-              "Whether to use <dragway>, <multilane> or <malidrive>. Default is dragway.");
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage>. Default is dragway.");
 DEFINE_double(phase_duration, 2, "Duration of the phase in seconds.");
 DEFINE_double(timeout, 20., "Timeout for calling off the simulation in seconds.");
 
@@ -181,7 +182,10 @@ int Main(int argc, char* argv[]) {
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 
   const std::unique_ptr<const Timer> timer = CreateTimer(TimerType::kChronoTimer);

--- a/src/applications/maliput_dynamic_environment.cc
+++ b/src/applications/maliput_dynamic_environment.cc
@@ -180,9 +180,9 @@ int Main(int argc, char* argv[]) {
        FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_use_userdata_traffic_direction,
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
-       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
        FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});

--- a/src/applications/maliput_gflags.h
+++ b/src/applications/maliput_gflags.h
@@ -122,3 +122,8 @@
   DEFINE_string(osm_file, "", "OSM file path."); \
   DEFINE_string(origin, "{0., 0.}", "OSM map's origin lat/long coordinate.");
 #endif  // MALIPUT_OSM_PROPERTIES_FLAGS
+
+#ifndef MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS
+
+#define MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS() DEFINE_string(gpkg_file, "", "GeoPackage file path.");
+#endif  // MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -123,9 +123,9 @@ int Main(int argc, char* argv[]) {
          FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_use_userdata_traffic_direction,
          FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
          FLAGS_intersection_book_file},
-        {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
-         maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+        {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
+         FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+         FLAGS_intersection_book_file},
         {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
          FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
          FLAGS_intersection_book_file}));

--- a/src/applications/maliput_measure_load_time.cc
+++ b/src/applications/maliput_measure_load_time.cc
@@ -67,10 +67,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
-              "Whether to use <dragway>, <multilane> or <malidrive>. Default is malidrive.");
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage>. Default is malidrive.");
 DEFINE_int32(iterations, 1, "Number of iterations for loading the Road Geometry.");
 
 // Measure the time that it takes to create the RoadNetwork using the implementation that `maliput_implementation`
@@ -87,10 +88,12 @@ double MeasureLoadTime(MaliputImplementation maliput_implementation,
                        const DragwayBuildProperties& dragway_build_properties,
                        const MultilaneBuildProperties& multilane_build_properties,
                        const MalidriveBuildProperties& malidrive_build_properties,
-                       const MaliputOsmBuildProperties& maliput_osm_build_properties) {
+                       const MaliputOsmBuildProperties& maliput_osm_build_properties,
+                       const MaliputGeopackageBuildProperties& maliput_geopackage_build_properties) {
   const auto start = std::chrono::high_resolution_clock::now();
-  const auto rn = LoadRoadNetwork(maliput_implementation, dragway_build_properties, multilane_build_properties,
-                                  malidrive_build_properties, maliput_osm_build_properties);
+  const auto rn =
+      LoadRoadNetwork(maliput_implementation, dragway_build_properties, multilane_build_properties,
+                      malidrive_build_properties, maliput_osm_build_properties, maliput_geopackage_build_properties);
   const auto end = std::chrono::high_resolution_clock::now();
   const std::chrono::duration<double> duration = (end - start);
   return duration.count();
@@ -122,7 +125,10 @@ int Main(int argc, char* argv[]) {
          FLAGS_intersection_book_file},
         {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
          maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file}));
+         FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+        {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+         FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+         FLAGS_intersection_book_file}));
   }
   const double mean_time = (std::accumulate(times.begin(), times.end(), 0.)) / static_cast<double>(times.size());
   maliput::log()->info("\tMean time was: ", mean_time, "s out of ", FLAGS_iterations, " iterations.\n");

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -1255,9 +1255,9 @@ int Main(int argc, char* argv[]) {
        FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_use_userdata_traffic_direction,
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
-       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
        FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});

--- a/src/applications/maliput_query.cc
+++ b/src/applications/maliput_query.cc
@@ -79,9 +79,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
-DEFINE_string(maliput_backend, "malidrive", "Whether to use <dragway>, <multilane> or <malidrive> maliput backend.");
+DEFINE_string(maliput_backend, "malidrive",
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage> maliput backend.");
 
 namespace maliput {
 namespace integration {
@@ -1255,7 +1257,10 @@ int Main(int argc, char* argv[]) {
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   MALIPUT_DEMAND(rn != nullptr);
   const auto end = std::chrono::high_resolution_clock::now();
   const std::chrono::duration<double> duration = (end - start);

--- a/src/applications/maliput_to_dot.cc
+++ b/src/applications/maliput_to_dot.cc
@@ -64,9 +64,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
-DEFINE_string(maliput_backend, "dragway", "Whether to use <dragway>, <multilane> or <malidrive>. Default is dragway.");
+DEFINE_string(maliput_backend, "dragway",
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage>. Default is dragway.");
 
 // Gflags for output files.
 DEFINE_string(dot_dir_path, ".", "Directory to contain DOT file.");
@@ -114,7 +116,10 @@ maliput_to_dot --maliput_backend malidrive --xodr_file_path TShapeRoad.xodr
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
 
   // Creates the destination directory if it does not already exist.

--- a/src/applications/maliput_to_dot.cc
+++ b/src/applications/maliput_to_dot.cc
@@ -114,9 +114,9 @@ maliput_to_dot --maliput_backend malidrive --xodr_file_path TShapeRoad.xodr
        FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_use_userdata_traffic_direction,
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
-       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
        FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -67,9 +67,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
-DEFINE_string(maliput_backend, "dragway", "Whether to use <dragway>, <multilane> or <malidrive>. Default is dragway.");
+DEFINE_string(maliput_backend, "dragway",
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage>. Default is dragway.");
 
 // Gflag to enable .urdf file creation.
 DEFINE_bool(urdf, false, "Enable URDF file creation.");
@@ -141,7 +143,10 @@ int Main(int argc, char* argv[]) {
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->info(
       "RoadNetwork loaded successfully in ",
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - load_time_now).count(),

--- a/src/applications/maliput_to_obj.cc
+++ b/src/applications/maliput_to_obj.cc
@@ -141,9 +141,9 @@ int Main(int argc, char* argv[]) {
        FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_use_userdata_traffic_direction,
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
-       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
        FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -94,9 +94,9 @@ int Main(int argc, char* argv[]) {
        FLAGS_omit_nondrivable_lanes, FLAGS_integrator_accuracy_multiplier, FLAGS_use_userdata_traffic_direction,
        FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file},
-      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
-       maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, maliput::math::Vector2::FromStr(FLAGS_origin),
+       FLAGS_rule_registry_file, FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file},
       {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
        FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
        FLAGS_intersection_book_file});

--- a/src/applications/maliput_to_string.cc
+++ b/src/applications/maliput_to_string.cc
@@ -62,10 +62,11 @@ MULTILANE_PROPERTIES_FLAGS();
 DRAGWAY_PROPERTIES_FLAGS();
 MALIDRIVE_PROPERTIES_FLAGS();
 MALIPUT_OSM_PROPERTIES_FLAGS();
+MALIPUT_GEOPACKAGE_PROPERTIES_FLAGS();
 MALIPUT_APPLICATION_DEFINE_LOG_LEVEL_FLAG();
 
 DEFINE_string(maliput_backend, "malidrive",
-              "Whether to use <dragway>, <multilane> or <malidrive>. Default is malidrive.");
+              "Whether to use <dragway>, <multilane>, <malidrive>, <osm> or <geopackage>. Default is malidrive.");
 DEFINE_bool(check_invariants, false, "Whether to enable maliput invariants verification.");
 // Gflags to select options for serialization.
 DEFINE_bool(include_type_labels, false, "Whether to include type labels in the output string");
@@ -95,7 +96,10 @@ int Main(int argc, char* argv[]) {
        FLAGS_intersection_book_file},
       {FLAGS_osm_file, FLAGS_linear_tolerance, FLAGS_max_linear_tolerance,
        maliput::math::Vector2::FromStr(FLAGS_origin), FLAGS_rule_registry_file, FLAGS_road_rule_book_file,
-       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file});
+       FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file, FLAGS_intersection_book_file},
+      {FLAGS_gpkg_file, FLAGS_linear_tolerance, FLAGS_angular_tolerance, FLAGS_rule_registry_file,
+       FLAGS_road_rule_book_file, FLAGS_traffic_light_book_file, FLAGS_phase_ring_book_file,
+       FLAGS_intersection_book_file});
   log()->info("RoadNetwork loaded successfully.");
   if (FLAGS_check_invariants) {
     log()->info("Checking invariants...");

--- a/src/integration/CMakeLists.txt
+++ b/src/integration/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(integration
     maliput_malidrive::loader
     maliput_multilane::maliput_multilane
     maliput_osm::builder
+    maliput_geopackage::builder
     yaml-cpp
 )
 

--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -47,6 +47,7 @@
 #include <maliput/common/logger.h>
 #include <maliput/common/maliput_abort.h>
 #include <maliput_dragway/road_geometry.h>
+#include <maliput_geopackage/builder/road_network_builder.h>
 #include <maliput_malidrive/builder/road_network_builder.h>
 #include <maliput_malidrive/constants.h>
 #include <maliput_malidrive/loader/loader.h>
@@ -54,7 +55,6 @@
 #include <maliput_multilane/loader.h>
 #include <maliput_multilane/road_network_builder.h>
 #include <maliput_osm/builder/road_network_builder.h>
-#include <maliput_geopackage/builder/road_network_builder.h>
 #include <yaml-cpp/yaml.h>
 
 namespace maliput {
@@ -68,19 +68,15 @@ constexpr char MALIPUT_GEOPACKAGE_RESOURCE_ROOT[] = "MALIPUT_GEOPACKAGE_RESOURCE
 
 // Holds the conversions from MaliputImplementation to std::string.
 const std::map<MaliputImplementation, std::string> maliput_impl_to_string{
-    {MaliputImplementation::kDragway, "dragway"},
-    {MaliputImplementation::kMalidrive, "malidrive"},
-    {MaliputImplementation::kMultilane, "multilane"},
-    {MaliputImplementation::kOsm, "osm"},
+    {MaliputImplementation::kDragway, "dragway"},       {MaliputImplementation::kMalidrive, "malidrive"},
+    {MaliputImplementation::kMultilane, "multilane"},   {MaliputImplementation::kOsm, "osm"},
     {MaliputImplementation::kGeopackage, "geopackage"},
 };
 
 // Holds the conversions from std::string to MaliputImplementation.
 const std::map<std::string, MaliputImplementation> string_to_maliput_impl{
-    {"dragway", MaliputImplementation::kDragway},
-    {"malidrive", MaliputImplementation::kMalidrive},
-    {"multilane", MaliputImplementation::kMultilane},
-    {"osm", MaliputImplementation::kOsm},
+    {"dragway", MaliputImplementation::kDragway},       {"malidrive", MaliputImplementation::kMalidrive},
+    {"multilane", MaliputImplementation::kMultilane},   {"osm", MaliputImplementation::kOsm},
     {"geopackage", MaliputImplementation::kGeopackage},
 };
 
@@ -245,30 +241,29 @@ std::unique_ptr<api::RoadNetwork> CreateMaliputGeopackageRoadNetwork(
 
   std::map<std::string, std::string> build_configuration;
   build_configuration.emplace("road_geometry_id", "maliput_geopackage_rg");
-  build_configuration.emplace("gpkg_file",
-                              GetResource(MaliputImplementation::kGeopackage, build_properties.gpkg_file));
+  build_configuration.emplace("gpkg_file", GetResource(MaliputImplementation::kGeopackage, build_properties.gpkg_file));
   build_configuration.emplace("linear_tolerance", std::to_string(build_properties.linear_tolerance));
   build_configuration.emplace("angular_tolerance", std::to_string(build_properties.angular_tolerance));
   build_configuration.emplace("inertial_to_backend_frame_translation", "{0., 0., 0.}");
   if (!build_properties.rule_registry_file.empty()) {
-    build_configuration.emplace(
-        "rule_registry", GetResource(MaliputImplementation::kGeopackage, build_properties.rule_registry_file));
+    build_configuration.emplace("rule_registry",
+                                GetResource(MaliputImplementation::kGeopackage, build_properties.rule_registry_file));
   }
   if (!build_properties.road_rule_book_file.empty()) {
-    build_configuration.emplace(
-        "road_rule_book", GetResource(MaliputImplementation::kGeopackage, build_properties.road_rule_book_file));
+    build_configuration.emplace("road_rule_book",
+                                GetResource(MaliputImplementation::kGeopackage, build_properties.road_rule_book_file));
   }
   if (!build_properties.traffic_light_book_file.empty()) {
     build_configuration.emplace("traffic_light_book", GetResource(MaliputImplementation::kGeopackage,
-                                                                   build_properties.traffic_light_book_file));
+                                                                  build_properties.traffic_light_book_file));
   }
   if (!build_properties.phase_ring_book_file.empty()) {
-    build_configuration.emplace(
-        "phase_ring_book", GetResource(MaliputImplementation::kGeopackage, build_properties.phase_ring_book_file));
+    build_configuration.emplace("phase_ring_book",
+                                GetResource(MaliputImplementation::kGeopackage, build_properties.phase_ring_book_file));
   }
   if (!build_properties.intersection_book_file.empty()) {
-    build_configuration.emplace("intersection_book", GetResource(MaliputImplementation::kGeopackage,
-                                                                  build_properties.intersection_book_file));
+    build_configuration.emplace(
+        "intersection_book", GetResource(MaliputImplementation::kGeopackage, build_properties.intersection_book_file));
   }
 
   return maliput_geopackage::builder::RoadNetworkBuilder(build_configuration)();
@@ -316,7 +311,6 @@ std::string GetResource(const MaliputImplementation& maliput_implementation, con
   }
   return file_path.empty() ? resource_name : file_path;
 }
-
 
 }  // namespace integration
 }  // namespace maliput

--- a/src/integration/tools.cc
+++ b/src/integration/tools.cc
@@ -54,6 +54,7 @@
 #include <maliput_multilane/loader.h>
 #include <maliput_multilane/road_network_builder.h>
 #include <maliput_osm/builder/road_network_builder.h>
+#include <maliput_geopackage/builder/road_network_builder.h>
 #include <yaml-cpp/yaml.h>
 
 namespace maliput {
@@ -63,6 +64,7 @@ namespace {
 constexpr char MALIPUT_MALIDRIVE_RESOURCE_ROOT[] = "MALIPUT_MALIDRIVE_RESOURCE_ROOT";
 constexpr char MULTILANE_RESOURCE_ROOT[] = "MULTILANE_RESOURCE_ROOT";
 constexpr char MALIPUT_OSM_RESOURCE_ROOT[] = "MALIPUT_OSM_RESOURCE_ROOT";
+constexpr char MALIPUT_GEOPACKAGE_RESOURCE_ROOT[] = "MALIPUT_GEOPACKAGE_RESOURCE_ROOT";
 
 // Holds the conversions from MaliputImplementation to std::string.
 const std::map<MaliputImplementation, std::string> maliput_impl_to_string{
@@ -70,6 +72,7 @@ const std::map<MaliputImplementation, std::string> maliput_impl_to_string{
     {MaliputImplementation::kMalidrive, "malidrive"},
     {MaliputImplementation::kMultilane, "multilane"},
     {MaliputImplementation::kOsm, "osm"},
+    {MaliputImplementation::kGeopackage, "geopackage"},
 };
 
 // Holds the conversions from std::string to MaliputImplementation.
@@ -78,6 +81,7 @@ const std::map<std::string, MaliputImplementation> string_to_maliput_impl{
     {"malidrive", MaliputImplementation::kMalidrive},
     {"multilane", MaliputImplementation::kMultilane},
     {"osm", MaliputImplementation::kOsm},
+    {"geopackage", MaliputImplementation::kGeopackage},
 };
 
 // @returns @p file_name 's path located at @p env path. If not located, an empty string is returned.
@@ -234,11 +238,48 @@ std::unique_ptr<api::RoadNetwork> CreateMaliputOsmRoadNetwork(const MaliputOsmBu
   return maliput_osm::builder::RoadNetworkBuilder(build_configuration)();
 }
 
-std::unique_ptr<api::RoadNetwork> LoadRoadNetwork(MaliputImplementation maliput_implementation,
-                                                  const DragwayBuildProperties& dragway_build_properties,
-                                                  const MultilaneBuildProperties& multilane_build_properties,
-                                                  const MalidriveBuildProperties& malidrive_build_properties,
-                                                  const MaliputOsmBuildProperties& maliput_osm_build_properties) {
+std::unique_ptr<api::RoadNetwork> CreateMaliputGeopackageRoadNetwork(
+    const MaliputGeopackageBuildProperties& build_properties) {
+  maliput::log()->debug("Building maliput_geopackage RoadNetwork.");
+  MALIPUT_VALIDATE(!build_properties.gpkg_file.empty(), "gpkg_file cannot be empty.");
+
+  std::map<std::string, std::string> build_configuration;
+  build_configuration.emplace("road_geometry_id", "maliput_geopackage_rg");
+  build_configuration.emplace("gpkg_file",
+                              GetResource(MaliputImplementation::kGeopackage, build_properties.gpkg_file));
+  build_configuration.emplace("linear_tolerance", std::to_string(build_properties.linear_tolerance));
+  build_configuration.emplace("angular_tolerance", std::to_string(build_properties.angular_tolerance));
+  build_configuration.emplace("inertial_to_backend_frame_translation", "{0., 0., 0.}");
+  if (!build_properties.rule_registry_file.empty()) {
+    build_configuration.emplace(
+        "rule_registry", GetResource(MaliputImplementation::kGeopackage, build_properties.rule_registry_file));
+  }
+  if (!build_properties.road_rule_book_file.empty()) {
+    build_configuration.emplace(
+        "road_rule_book", GetResource(MaliputImplementation::kGeopackage, build_properties.road_rule_book_file));
+  }
+  if (!build_properties.traffic_light_book_file.empty()) {
+    build_configuration.emplace("traffic_light_book", GetResource(MaliputImplementation::kGeopackage,
+                                                                   build_properties.traffic_light_book_file));
+  }
+  if (!build_properties.phase_ring_book_file.empty()) {
+    build_configuration.emplace(
+        "phase_ring_book", GetResource(MaliputImplementation::kGeopackage, build_properties.phase_ring_book_file));
+  }
+  if (!build_properties.intersection_book_file.empty()) {
+    build_configuration.emplace("intersection_book", GetResource(MaliputImplementation::kGeopackage,
+                                                                  build_properties.intersection_book_file));
+  }
+
+  return maliput_geopackage::builder::RoadNetworkBuilder(build_configuration)();
+}
+
+std::unique_ptr<api::RoadNetwork> LoadRoadNetwork(
+    MaliputImplementation maliput_implementation, const DragwayBuildProperties& dragway_build_properties,
+    const MultilaneBuildProperties& multilane_build_properties,
+    const MalidriveBuildProperties& malidrive_build_properties,
+    const MaliputOsmBuildProperties& maliput_osm_build_properties,
+    const MaliputGeopackageBuildProperties& maliput_geopackage_build_properties) {
   switch (maliput_implementation) {
     case MaliputImplementation::kDragway:
       return CreateDragwayRoadNetwork(dragway_build_properties);
@@ -248,6 +289,8 @@ std::unique_ptr<api::RoadNetwork> LoadRoadNetwork(MaliputImplementation maliput_
       return CreateMalidriveRoadNetwork(malidrive_build_properties);
     case MaliputImplementation::kOsm:
       return CreateMaliputOsmRoadNetwork(maliput_osm_build_properties);
+    case MaliputImplementation::kGeopackage:
+      return CreateMaliputGeopackageRoadNetwork(maliput_geopackage_build_properties);
     default:
       MALIPUT_ABORT_MESSAGE("Error loading RoadNetwork. Unknown implementation.");
   }
@@ -265,11 +308,15 @@ std::string GetResource(const MaliputImplementation& maliput_implementation, con
     case MaliputImplementation::kOsm:
       file_path = GetFilePathFromEnv("resources/osm/" + resource_name, MALIPUT_OSM_RESOURCE_ROOT);
       break;
+    case MaliputImplementation::kGeopackage:
+      file_path = GetFilePathFromEnv("resources/gpkg/" + resource_name, MALIPUT_GEOPACKAGE_RESOURCE_ROOT);
+      break;
     default:
       break;
   }
   return file_path.empty() ? resource_name : file_path;
 }
+
 
 }  // namespace integration
 }  // namespace maliput

--- a/src/integration/tools.h
+++ b/src/integration/tools.h
@@ -41,10 +41,11 @@ namespace integration {
 
 /// Available maliput implementations.
 enum class MaliputImplementation {
-  kMalidrive,  //< malidrive implementation.
-  kDragway,    //< dragway implementation.
-  kMultilane,  //< multilane implementation.
-  kOsm,        //< osm implementation.
+  kMalidrive,   //< malidrive implementation.
+  kDragway,     //< dragway implementation.
+  kMultilane,   //< multilane implementation.
+  kOsm,         //< osm implementation.
+  kGeopackage,  //< geopackage implementation.
 };
 
 /// Returns the std::string version of `maliput_impl`.
@@ -105,6 +106,18 @@ struct MaliputOsmBuildProperties {
   std::string intersection_book_file{""};
 };
 
+/// Contains the attributes needed for building a maliput_geopackage RoadNetwork.
+struct MaliputGeopackageBuildProperties {
+  std::string gpkg_file{""};
+  double linear_tolerance{1e-5};
+  double angular_tolerance{1e-3};
+  std::string rule_registry_file{""};
+  std::string road_rule_book_file{""};
+  std::string traffic_light_book_file{""};
+  std::string phase_ring_book_file{""};
+  std::string intersection_book_file{""};
+};
+
 /// Builds an api::RoadNetwork based on Dragway implementation.
 /// @param build_properties Holds the properties to build the RoadNetwork.
 /// @return A maliput::api::RoadNetwork.
@@ -131,20 +144,30 @@ std::unique_ptr<api::RoadNetwork> CreateMalidriveRoadNetwork(const MalidriveBuil
 /// @throw maliput::common::assertion_error When `build_properties.osm_file` is empty.
 std::unique_ptr<api::RoadNetwork> CreateMaliputOsmRoadNetwork(const MaliputOsmBuildProperties& build_properties);
 
+/// Builds an api::RoadNetwork based on MaliputGeopackage implementation.
+/// @param build_properties Holds the properties to build the RoadNetwork.
+/// @return A maliput::api::RoadNetwork.
+///
+/// @throw maliput::common::assertion_error When `build_properties.gpkg_file` is empty.
+std::unique_ptr<api::RoadNetwork> CreateMaliputGeopackageRoadNetwork(
+    const MaliputGeopackageBuildProperties& build_properties);
+
 /// Builds an api::RoadNetwork using the implementation that `maliput_implementation` describes.
 /// @param maliput_implementation One of MaliputImplementation. (kDragway, kMultilane, kMalidrive).
 /// @param dragway_build_properties Holds the properties to build a dragway RoadNetwork.
 /// @param multilane_build_properties Holds the properties to build a multilane RoadNetwork.
 /// @param malidrive_build_properties Holds the properties to build a malidrive RoadNetwork.
 /// @param maliput_osm_build_properties Holds the properties to build a maliput_osm RoadNetwork.
+/// @param maliput_geopackage_build_properties Holds the properties to build a maliput_geopackage RoadNetwork.
 /// @return A maliput::api::RoadNetwork.
 ///
 /// @throw maliput::common::assertion_error When `maliput_implementation` is unknown.
-std::unique_ptr<api::RoadNetwork> LoadRoadNetwork(MaliputImplementation maliput_implementation,
-                                                  const DragwayBuildProperties& dragway_build_properties,
-                                                  const MultilaneBuildProperties& multilane_build_properties,
-                                                  const MalidriveBuildProperties& malidrive_build_properties,
-                                                  const MaliputOsmBuildProperties& maliput_osm_build_properties);
+std::unique_ptr<api::RoadNetwork> LoadRoadNetwork(
+    MaliputImplementation maliput_implementation, const DragwayBuildProperties& dragway_build_properties,
+    const MultilaneBuildProperties& multilane_build_properties,
+    const MalidriveBuildProperties& malidrive_build_properties,
+    const MaliputOsmBuildProperties& maliput_osm_build_properties,
+    const MaliputGeopackageBuildProperties& maliput_geopackage_build_properties);
 
 /// Obtains the correspondent path to the @p resource_name located at the maliput's implementation's resource directory
 /// if exists, otherwise it returns @p resource_name .


### PR DESCRIPTION
# Depends on https://github.com/maliput/maliput_geopackage/pull/38

# 🎉 New feature

Part of https://github.com/maliput/maliput_geopackage/issues/3

## Summary

Adds geopackage support

## Test it
```
maliput_query --maliput_backend=geopackage --gpkg_file=src/maliput_geopackage/resources/t_shape_road.gpkg --linear_tolerance=0.05 -- GetCurvature 1_0_1 0 0 0
```

<img width="1818" height="213" alt="image" src="https://github.com/user-attachments/assets/a680554e-1b37-4f0b-8db1-4b9083b0a969" />


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
